### PR TITLE
SASS-6482: Load prior data for Income journey

### DIFF
--- a/app/connectors/SelfEmploymentConnector.scala
+++ b/app/connectors/SelfEmploymentConnector.scala
@@ -33,6 +33,7 @@ class SelfEmploymentConnector @Inject() (http: HttpClient, appConfig: FrontendAp
   private def buildUrl(url: String) = s"${appConfig.selfEmploymentBEBaseUrl}/income-tax-self-employment/$url"
 
   def getBusinesses(nino: String, mtditid: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[GetBusinessesResponse] = {
+
     val url = buildUrl(s"individuals/business/details/$nino/list")
     http.GET[GetBusinessesResponse](url)(GetBusinessesHttpReads, hc.withExtraHeaders(headers = "mtditid" -> mtditid), ec)
   }
@@ -40,6 +41,7 @@ class SelfEmploymentConnector @Inject() (http: HttpClient, appConfig: FrontendAp
   def getBusiness(nino: String, businessId: BusinessId, mtditid: String)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext): Future[GetBusinessesResponse] = {
+
     val url = buildUrl(s"individuals/business/details/$nino/${businessId.value}")
     http.GET[GetBusinessesResponse](url)(GetBusinessesHttpReads, hc.withExtraHeaders(headers = "mtditid" -> mtditid), ec)
   }
@@ -47,6 +49,7 @@ class SelfEmploymentConnector @Inject() (http: HttpClient, appConfig: FrontendAp
   def getJourneyState(businessId: BusinessId, journey: String, taxYear: TaxYear, mtditid: String)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext): Future[JourneyStateResponse] = {
+
     val url = buildUrl(s"completed-section/${businessId.value}/$journey/${taxYear.value}")
     http.GET[JourneyStateResponse](url)(JourneyStateHttpReads, hc.withExtraHeaders(headers = "mtditid" -> mtditid), ec)
   }
@@ -54,6 +57,7 @@ class SelfEmploymentConnector @Inject() (http: HttpClient, appConfig: FrontendAp
   def saveJourneyState(businessId: BusinessId, journey: String, taxYear: TaxYear, complete: Boolean, mtditid: String)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext): Future[JourneyStateResponse] = {
+
     val url = buildUrl(s"completed-section/${businessId.value}/$journey/${taxYear.value}/$complete")
 
     http.PUT[String, JourneyStateResponse](url, "")(
@@ -66,6 +70,7 @@ class SelfEmploymentConnector @Inject() (http: HttpClient, appConfig: FrontendAp
   def getCompletedTradesWithStatuses(nino: String, taxYear: TaxYear, mtditid: String)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext): Future[GetTradesStatusResponse] = {
+
     val url = buildUrl(s"individuals/business/journey-states/$nino/${taxYear.value}")
     http.GET[GetTradesStatusResponse](url)(GetTradesStatusHttpReads, hc.withExtraHeaders(headers = "mtditid" -> mtditid), ec)
   }

--- a/app/connectors/SelfEmploymentConnector.scala
+++ b/app/connectors/SelfEmploymentConnector.scala
@@ -33,7 +33,6 @@ class SelfEmploymentConnector @Inject() (http: HttpClient, appConfig: FrontendAp
   private def buildUrl(url: String) = s"${appConfig.selfEmploymentBEBaseUrl}/income-tax-self-employment/$url"
 
   def getBusinesses(nino: String, mtditid: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[GetBusinessesResponse] = {
-
     val url = buildUrl(s"individuals/business/details/$nino/list")
     http.GET[GetBusinessesResponse](url)(GetBusinessesHttpReads, hc.withExtraHeaders(headers = "mtditid" -> mtditid), ec)
   }
@@ -41,7 +40,6 @@ class SelfEmploymentConnector @Inject() (http: HttpClient, appConfig: FrontendAp
   def getBusiness(nino: String, businessId: BusinessId, mtditid: String)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext): Future[GetBusinessesResponse] = {
-
     val url = buildUrl(s"individuals/business/details/$nino/${businessId.value}")
     http.GET[GetBusinessesResponse](url)(GetBusinessesHttpReads, hc.withExtraHeaders(headers = "mtditid" -> mtditid), ec)
   }
@@ -49,7 +47,6 @@ class SelfEmploymentConnector @Inject() (http: HttpClient, appConfig: FrontendAp
   def getJourneyState(businessId: BusinessId, journey: String, taxYear: TaxYear, mtditid: String)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext): Future[JourneyStateResponse] = {
-
     val url = buildUrl(s"completed-section/${businessId.value}/$journey/${taxYear.value}")
     http.GET[JourneyStateResponse](url)(JourneyStateHttpReads, hc.withExtraHeaders(headers = "mtditid" -> mtditid), ec)
   }
@@ -57,7 +54,6 @@ class SelfEmploymentConnector @Inject() (http: HttpClient, appConfig: FrontendAp
   def saveJourneyState(businessId: BusinessId, journey: String, taxYear: TaxYear, complete: Boolean, mtditid: String)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext): Future[JourneyStateResponse] = {
-
     val url = buildUrl(s"completed-section/${businessId.value}/$journey/${taxYear.value}/$complete")
 
     http.PUT[String, JourneyStateResponse](url, "")(
@@ -70,7 +66,6 @@ class SelfEmploymentConnector @Inject() (http: HttpClient, appConfig: FrontendAp
   def getCompletedTradesWithStatuses(nino: String, taxYear: TaxYear, mtditid: String)(implicit
       hc: HeaderCarrier,
       ec: ExecutionContext): Future[GetTradesStatusResponse] = {
-
     val url = buildUrl(s"individuals/business/journey-states/$nino/${taxYear.value}")
     http.GET[GetTradesStatusResponse](url)(GetTradesStatusHttpReads, hc.withExtraHeaders(headers = "mtditid" -> mtditid), ec)
   }

--- a/app/controllers/actions/SubmittedDataRetrievalActionImpl.scala
+++ b/app/controllers/actions/SubmittedDataRetrievalActionImpl.scala
@@ -20,7 +20,7 @@ import cats.data.EitherT
 import cats.implicits._
 import connectors.ContentHttpReads
 import controllers.handleApiResult
-import models.common.{BusinessId, JourneyContext, Mtditid, UserId}
+import models.common.{BusinessId, JourneyContext, UserId}
 import models.database.UserAnswers
 import models.domain.ApiResultT
 import models.errors.ServiceError
@@ -37,7 +37,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait SubmittedDataRetrievalAction extends ActionTransformer[OptionalDataRequest, OptionalDataRequest]
 
-class SubmittedDataRetrievalActionImpl[SubsetOfAnswers: Format](journeyContext: Mtditid => JourneyContext,
+class SubmittedDataRetrievalActionImpl[SubsetOfAnswers: Format](journeyContext: OptionalDataRequest[_] => JourneyContext,
                                                                 selfEmploymentService: SelfEmploymentServiceBase,
                                                                 sessionRepository: SessionRepositoryBase)(implicit ec: ExecutionContext)
     extends SubmittedDataRetrievalAction
@@ -47,7 +47,7 @@ class SubmittedDataRetrievalActionImpl[SubsetOfAnswers: Format](journeyContext: 
   protected def executionContext: ExecutionContext = ec
 
   protected[actions] def transform[A](request: OptionalDataRequest[A]): Future[OptionalDataRequest[A]] = {
-    val ctx: JourneyContext     = journeyContext(request.mtditid)
+    val ctx: JourneyContext     = journeyContext(request)
     val hasAtLeastOneUserAnswer = hasAtLeastOneUserAnswerForJourney(ctx.businessId, ctx.journey, request.userAnswers)
 
     if (hasAtLeastOneUserAnswer) {

--- a/app/controllers/actions/SubmittedDataRetrievalActionProvider.scala
+++ b/app/controllers/actions/SubmittedDataRetrievalActionProvider.scala
@@ -27,8 +27,8 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class SubmittedDataRetrievalActionProvider @Inject() (selfEmploymentService: SelfEmploymentServiceBase, sessionRepository: SessionRepositoryBase) {
-  def apply[SubsetOfAnswers: Format](journeyContext: OptionalDataRequest[_] => JourneyContext)(implicit
+  def apply[SubsetOfAnswers: Format](mkJourneyContext: OptionalDataRequest[_] => JourneyContext)(implicit
       ec: ExecutionContext): SubmittedDataRetrievalAction =
-    new SubmittedDataRetrievalActionImpl[SubsetOfAnswers](journeyContext, selfEmploymentService, sessionRepository)
+    new SubmittedDataRetrievalActionImpl[SubsetOfAnswers](mkJourneyContext, selfEmploymentService, sessionRepository)
 
 }

--- a/app/controllers/actions/SubmittedDataRetrievalActionProvider.scala
+++ b/app/controllers/actions/SubmittedDataRetrievalActionProvider.scala
@@ -16,7 +16,8 @@
 
 package controllers.actions
 
-import models.common.{JourneyContext, Mtditid}
+import models.common.JourneyContext
+import models.requests.OptionalDataRequest
 import play.api.libs.json.Format
 import repositories.SessionRepositoryBase
 import services.SelfEmploymentServiceBase
@@ -26,6 +27,8 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class SubmittedDataRetrievalActionProvider @Inject() (selfEmploymentService: SelfEmploymentServiceBase, sessionRepository: SessionRepositoryBase) {
-  def apply[SubsetOfAnswers: Format](journeyContext: Mtditid => JourneyContext)(implicit ec: ExecutionContext): SubmittedDataRetrievalAction =
+  def apply[SubsetOfAnswers: Format](journeyContext: OptionalDataRequest[_] => JourneyContext)(implicit
+      ec: ExecutionContext): SubmittedDataRetrievalAction =
     new SubmittedDataRetrievalActionImpl[SubsetOfAnswers](journeyContext, selfEmploymentService, sessionRepository)
+
 }

--- a/app/controllers/journeys/income/IncomeCYAController.scala
+++ b/app/controllers/journeys/income/IncomeCYAController.scala
@@ -50,7 +50,7 @@ class IncomeCYAController @Inject() (override val messagesApi: MessagesApi,
 
   def onPageLoad(taxYear: TaxYear, businessId: BusinessId): Action[AnyContent] =
     (identify andThen getUserAnswers andThen
-      getJourneyAnswersIfAny[IncomeJourneyAnswers](JourneyAnswersContext(taxYear, businessId, _, Journey.Income)) andThen
+      getJourneyAnswersIfAny[IncomeJourneyAnswers](request => request.mkJourneyNinoContext(taxYear, businessId, Journey.Income)) andThen
       requireData) { implicit request =>
       val user = request.userType
 

--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -18,8 +18,9 @@ package models.requests
 
 import controllers.actions.AuthenticatedIdentifierAction.User
 import controllers.standard
-import models.common.{BusinessId, Mtditid, Nino, UserType}
+import models.common.{BusinessId, JourneyAnswersContext, JourneyContextWithNino, Mtditid, Nino, TaxYear, UserType}
 import models.database.UserAnswers
+import models.journeys.Journey
 import play.api.libs.json.Reads
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{Request, Result, WrappedRequest}
@@ -31,6 +32,12 @@ case class OptionalDataRequest[A](request: Request[A], userId: String, user: Use
   val nino: Nino           = Nino(user.nino)
   val answers: UserAnswers = userAnswers.getOrElse(UserAnswers(userId))
   val mtditid: Mtditid     = Mtditid(user.mtditid)
+
+  def mkJourneyAnswersContext(taxYear: TaxYear, businessId: BusinessId, journey: Journey, extraContext: Option[String] = None) =
+    JourneyAnswersContext(taxYear, businessId, mtditid, journey, extraContext)
+
+  def mkJourneyNinoContext(taxYear: TaxYear, businessId: BusinessId, journey: Journey, extraContext: Option[String] = None) =
+    JourneyContextWithNino(taxYear, nino, businessId, mtditid, journey, extraContext)
 }
 
 case class DataRequest[A](request: Request[A], userId: String, user: User, userAnswers: UserAnswers) extends WrappedRequest[A](request) {

--- a/test/controllers/actions/FakeSubmittedDataRetrievalActionProvider.scala
+++ b/test/controllers/actions/FakeSubmittedDataRetrievalActionProvider.scala
@@ -28,7 +28,7 @@ import scala.concurrent.ExecutionContext
 case class FakeSubmittedDataRetrievalActionProvider()
     extends SubmittedDataRetrievalActionProvider(SelfEmploymentServiceStub(), StubSessionRepository()) {
 
-  override def apply[SubsetOfAnswers: Format](journeyContext: OptionalDataRequest[_] => JourneyContext)(implicit
-      ec: ExecutionContext): SubmittedDataRetrievalAction =
+  override def apply[SubsetOfAnswers: Format](mkJourneyContext: OptionalDataRequest[_] => JourneyContext)(implicit
+                                                                                                          ec: ExecutionContext): SubmittedDataRetrievalAction =
     StubSubmittedDataRetrievalAction()
 }

--- a/test/controllers/actions/FakeSubmittedDataRetrievalActionProvider.scala
+++ b/test/controllers/actions/FakeSubmittedDataRetrievalActionProvider.scala
@@ -16,7 +16,8 @@
 
 package controllers.actions
 
-import models.common.{JourneyContext, Mtditid}
+import models.common.JourneyContext
+import models.requests.OptionalDataRequest
 import play.api.libs.json.Format
 import stubs.controllers.actions.StubSubmittedDataRetrievalAction
 import stubs.repositories.StubSessionRepository
@@ -27,7 +28,7 @@ import scala.concurrent.ExecutionContext
 case class FakeSubmittedDataRetrievalActionProvider()
     extends SubmittedDataRetrievalActionProvider(SelfEmploymentServiceStub(), StubSessionRepository()) {
 
-  override def apply[SubsetOfAnswers: Format](journeyContext: Mtditid => JourneyContext)(implicit
+  override def apply[SubsetOfAnswers: Format](journeyContext: OptionalDataRequest[_] => JourneyContext)(implicit
       ec: ExecutionContext): SubmittedDataRetrievalAction =
     StubSubmittedDataRetrievalAction()
 }

--- a/test/controllers/actions/FakeSubmittedDataRetrievalActionProvider.scala
+++ b/test/controllers/actions/FakeSubmittedDataRetrievalActionProvider.scala
@@ -29,6 +29,6 @@ case class FakeSubmittedDataRetrievalActionProvider()
     extends SubmittedDataRetrievalActionProvider(SelfEmploymentServiceStub(), StubSessionRepository()) {
 
   override def apply[SubsetOfAnswers: Format](mkJourneyContext: OptionalDataRequest[_] => JourneyContext)(implicit
-                                                                                                          ec: ExecutionContext): SubmittedDataRetrievalAction =
+      ec: ExecutionContext): SubmittedDataRetrievalAction =
     StubSubmittedDataRetrievalAction()
 }

--- a/test/controllers/actions/SubmittedDataRetrievalActionImplSpec.scala
+++ b/test/controllers/actions/SubmittedDataRetrievalActionImplSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase.{businessId, convertScalaFuture, taxYear}
 import cats.implicits._
 import controllers.actions.AuthenticatedIdentifierAction.User
 import controllers.actions.SubmittedDataRetrievalActionImplSpec._
-import models.common.{JourneyAnswersContext, Mtditid}
+import models.common.JourneyAnswersContext
 import models.database.UserAnswers
 import models.journeys.Journey
 import models.requests.OptionalDataRequest
@@ -100,8 +100,8 @@ object SubmittedDataRetrievalActionImplSpec {
     lazy val service = SelfEmploymentServiceStub(
       submittedAnswers = submittedUerAnswers.some.asRight
     )
-    val repo = StubSessionRepository()
-    val ctx  = JourneyAnswersContext(taxYear, businessId, _: Mtditid, journey)
+    val repo                                                 = StubSessionRepository()
+    val ctx: OptionalDataRequest[_] => JourneyAnswersContext = req => JourneyAnswersContext(taxYear, businessId, req.mtditid, journey)
     val user = User(mtditid = "1234567890", arn = None, nino = "AA112233A", AffinityGroup.Individual.toString)
 
     val request = OptionalDataRequest[AnyContentAsEmpty.type](FakeRequest(), "userId", user, userAnswers)

--- a/test/controllers/actions/SubmittedDataRetrievalActionProviderSpec.scala
+++ b/test/controllers/actions/SubmittedDataRetrievalActionProviderSpec.scala
@@ -19,6 +19,7 @@ package controllers.actions
 import base.SpecBase.{businessId, taxYear}
 import models.common.JourneyAnswersContext
 import models.journeys.Journey
+import models.requests.OptionalDataRequest
 import org.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -35,8 +36,9 @@ class SubmittedDataRetrievalActionProviderSpec extends AnyWordSpecLike with Mock
       val service = mock[SelfEmploymentService]
       val repo    = mock[SessionRepository]
 
-      val underTest = new SubmittedDataRetrievalActionProvider(service, repo)
-      val result    = underTest[JsObject](JourneyAnswersContext(taxYear, businessId, _, Journey.TradeDetails))
+      val underTest                                            = new SubmittedDataRetrievalActionProvider(service, repo)
+      val ctx: OptionalDataRequest[_] => JourneyAnswersContext = req => JourneyAnswersContext(taxYear, businessId, req.mtditid, Journey.TradeDetails)
+      val result                                               = underTest[JsObject](ctx)
       result shouldBe a[SubmittedDataRetrievalActionImpl[_]]
     }
   }


### PR DESCRIPTION
Load prior data action may need to create NINO or non-NINO journey context. I added possibility to create any of them depending what is needed.