### PR TITLE
SASS-9204: Add NICS sample event (first version)

### DIFF
--- a/app/controllers/journeys/SectionCompletedStateController.scala
+++ b/app/controllers/journeys/SectionCompletedStateController.scala
@@ -54,7 +54,7 @@ class SectionCompletedStateController @Inject() (override val messagesApi: Messa
     implicit request =>
       val form: Form[Boolean] = formProvider(page, request.userType, userSpecificRequiredError = false)
       val preparedForm = service
-        .getJourneyStatus(JourneyAnswersContext(taxYear, businessId, request.mtditid, Journey.withName(journey)))
+        .getJourneyStatus(JourneyAnswersContext.fromNinoDataRequest(taxYear, businessId, request, Journey.withName(journey)))
         .value
         .map(_.fold(_ => form, fill(form, _)))
 
@@ -78,7 +78,7 @@ class SectionCompletedStateController @Inject() (override val messagesApi: Messa
           formWithErrors => Future.successful(BadRequest(view(formWithErrors, taxYear, businessId, Journey.withName(journey), mode))),
           answer =>
             handleResultT(
-              saveAndRedirect(JourneyAnswersContext(taxYear, businessId, request.mtditid, Journey.withName(journey)), answer)
+              saveAndRedirect(JourneyAnswersContext.fromNinoDataRequest(taxYear, businessId, request, Journey.withName(journey)), answer)
             )
         )
   }

--- a/app/controllers/journeys/capitalallowances/tailoring/CapitalAllowanceCYAController.scala
+++ b/app/controllers/journeys/capitalallowances/tailoring/CapitalAllowanceCYAController.scala
@@ -68,7 +68,7 @@ class CapitalAllowanceCYAController @Inject() (override val messagesApi: Message
 
   def onSubmit(taxYear: TaxYear, businessId: BusinessId): Action[AnyContent] = (identify andThen getUserAnswers andThen requireAnswers) async {
     implicit request =>
-      val context = JourneyAnswersContext(taxYear, businessId, request.mtditid, CapitalAllowancesTailoring)
+      val context = JourneyAnswersContext.fromNinoDataRequest(taxYear, businessId, request, CapitalAllowancesTailoring)
       val result  = service.submitAnswers[CapitalAllowancesTailoringAnswers](context, request.userAnswers)
 
       handleSubmitAnswersResult(context, result)

--- a/app/controllers/journeys/expenses/tailoring/ExpensesTailoringCYAController.scala
+++ b/app/controllers/journeys/expenses/tailoring/ExpensesTailoringCYAController.scala
@@ -84,10 +84,12 @@ class ExpensesTailoringCYAController @Inject() (override val messagesApi: Messag
               val journeyContext = JourneyContextWithNino(taxYear, request.nino, businessId, request.mtditid, ExpensesTailoring, Some("total"))
               (journeyContext, service.submitAnswers[AsOneTotalAnswers](journeyContext, request.userAnswers))
             case IndividualCategories =>
-              val journeyContext = JourneyAnswersContext(taxYear, businessId, request.mtditid, ExpensesTailoring, Some("categories"))
+              val journeyContext =
+                JourneyAnswersContext(taxYear, request.nino, businessId, request.mtditid, ExpensesTailoring, Some("categories"))
               (journeyContext, service.submitAnswers[ExpensesTailoringIndividualCategoriesAnswers](journeyContext, request.userAnswers))
             case NoExpenses =>
-              val journeyContext = JourneyAnswersContext(taxYear, businessId, request.mtditid, ExpensesTailoring, Some("none"))
+              val journeyContext =
+                JourneyAnswersContext(taxYear, request.nino, businessId, request.mtditid, ExpensesTailoring, Some("none"))
               (journeyContext, service.submitAnswers[NoExpensesAnswers.type](journeyContext, request.userAnswers))
           }
 

--- a/app/models/audit/AuditSectionName.scala
+++ b/app/models/audit/AuditSectionName.scala
@@ -16,15 +16,12 @@
 
 package models.audit
 
-import models.common.BusinessName
 import play.api.libs.json.{JsString, Writes}
 
-sealed abstract class SectionName(val name: String)
+sealed abstract class AuditSectionName(val name: String)
 
-object SectionName {
-  final case object ReviewSelfEmploymentSection                extends SectionName("reviewSelfEmployment")
-  final case class BusinessSection(businessName: BusinessName) extends SectionName(s"$businessName - Self Employment")
-  final case object NationalInsuranceContributonsSection       extends SectionName("nationalInsuranceContributions")
+object AuditSectionName {
+  final case object NationalInsuranceContributionsAuditSection extends AuditSectionName("nationalInsuranceContributions")
 
-  implicit val writes: Writes[SectionName] = (sectionName: SectionName) => JsString(sectionName.name)
+  implicit val writes: Writes[AuditSectionName] = (sectionName: AuditSectionName) => JsString(sectionName.name)
 }

--- a/app/models/audit/SelfEmploymentAuditEvent.scala
+++ b/app/models/audit/SelfEmploymentAuditEvent.scala
@@ -16,27 +16,40 @@
 
 package models.audit
 
-import models.common.{Mtditid, TaxYear}
+import models.common.{JourneyStatus, Mtditid, Nino, TaxYear}
 import models.journeys.Journey
 import play.api.libs.json.{JsObject, Json, OWrites, Writes}
 
 sealed trait SelfEmploymentAuditEvent
 
-final case class SelfEmploymentCYAnswersAuditEvent(
+final case class CYAnswersAuditEvent(
     mtditid: Mtditid,
+    nino: Nino,
     taxYear: TaxYear,
-    sectionName: SectionName,
+    sectionName: Option[AuditSectionName],
     journeyName: Journey,
     priorAnswers: Option[JsObject],
-    submittedAnswers: JsObject
+    submittedAnswers: JsObject,
+    isSuccessful: Boolean
 ) extends SelfEmploymentAuditEvent
 
-object SelfEmploymentCYAnswersAuditEvent {
-  implicit val writes: OWrites[SelfEmploymentCYAnswersAuditEvent] = Json.writes[SelfEmploymentCYAnswersAuditEvent]
+object CYAnswersAuditEvent {
+  implicit val writes: OWrites[CYAnswersAuditEvent] = Json.writes[CYAnswersAuditEvent]
+}
+
+final case class StatusAuditEvent(
+    priorStatus: JourneyStatus,
+    submittedStatus: JourneyStatus,
+    successful: Boolean
+) extends SelfEmploymentAuditEvent
+
+object StatusAuditEvent {
+  implicit val writes: OWrites[StatusAuditEvent] = Json.writes[StatusAuditEvent]
 }
 
 object SelfEmploymentAuditEvent {
-  implicit def writes: Writes[SelfEmploymentAuditEvent] = { case e: SelfEmploymentCYAnswersAuditEvent =>
-    Json.toJson(e)(SelfEmploymentCYAnswersAuditEvent.writes)
+  implicit def writes: Writes[SelfEmploymentAuditEvent] = {
+    case e: CYAnswersAuditEvent => Json.toJson(e)(CYAnswersAuditEvent.writes)
+    case e: StatusAuditEvent    => Json.toJson(e)(StatusAuditEvent.writes)
   }
 }

--- a/app/models/common/Nino.scala
+++ b/app/models/common/Nino.scala
@@ -16,6 +16,12 @@
 
 package models.common
 
+import play.api.libs.json.{JsString, Writes}
+
 final case class Nino(value: String) extends AnyVal {
   override def toString: String = value
+}
+
+object Nino {
+  implicit val writes: Writes[Nino] = nino => JsString(nino.value)
 }

--- a/app/models/journeys/nics/Class2NICsAnswers.scala
+++ b/app/models/journeys/nics/Class2NICsAnswers.scala
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-package models.audit
+package models.journeys.nics
 
-import enumeratum._
+import play.api.libs.json.{Format, Json}
 
-sealed abstract class AuditEventType(override val entryName: String) extends EnumEntry {
-  override def toString: String = entryName
-}
+case class Class2NICsAnswers(class2NICs: Boolean)
 
-object AuditEventType extends Enum[AuditEventType] with utils.PlayJsonEnum[AuditEventType] {
-  val values = findValues
-
-  final case object CreateOrUpdateNationalInsuranceContributionsAuditType
-      extends AuditEventType("CreateOrUpdateSelfEmploymentNationalInsuranceContributions")
+object Class2NICsAnswers {
+  implicit val formats: Format[Class2NICsAnswers] = Json.format[Class2NICsAnswers]
 }

--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -29,8 +29,15 @@ import queries.Gettable
 
 import scala.concurrent.{ExecutionContext, Future}
 
+sealed trait NinoDataRequest {
+  val userType: UserType
+  val nino: Nino
+  val mtditid: Mtditid
+}
+
 case class OptionalDataRequest[A](request: Request[A], userId: String, user: User, userAnswers: Option[UserAnswers])
-    extends WrappedRequest[A](request) {
+    extends WrappedRequest[A](request)
+    with NinoDataRequest {
   val userType: UserType   = user.userType
   val nino: Nino           = Nino(user.nino)
   val answers: UserAnswers = userAnswers.getOrElse(UserAnswers(userId))
@@ -40,7 +47,9 @@ case class OptionalDataRequest[A](request: Request[A], userId: String, user: Use
     JourneyContextWithNino(taxYear, nino, businessId, mtditid, journey, extraContext)
 }
 
-case class DataRequest[A](request: Request[A], userId: String, user: User, userAnswers: UserAnswers) extends WrappedRequest[A](request) {
+case class DataRequest[A](request: Request[A], userId: String, user: User, userAnswers: UserAnswers)
+    extends WrappedRequest[A](request)
+    with NinoDataRequest {
   val userType: UserType = user.userType
   val nino: Nino         = Nino(user.nino)
   val mtditid: Mtditid   = Mtditid(user.mtditid)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -115,7 +115,7 @@ play.i18n.langs = ["en", "cy"]
 # Microservice specific configuration
 # If you want to test audit events locally switch it to true and start datastream-stub
 auditing {
-  enabled = false
+  enabled = true
   auditSource = ${appName}
   consumer {
     baseUri {

--- a/it/connectors/SelfEmploymentConnectorISpec.scala
+++ b/it/connectors/SelfEmploymentConnectorISpec.scala
@@ -30,7 +30,7 @@ import utils.PagerDutyHelper.PagerDutyKeys.FOURXX_RESPONSE_FROM_CONNECTOR
 class SelfEmploymentConnectorISpec extends WiremockSpec with IntegrationBaseSpec {
 
   private def journeyNinoCtx(journey: Journey) = JourneyContextWithNino(taxYear, nino, businessId, mtditid, journey)
-  private def journeyCtx(journey: Journey)     = JourneyAnswersContext(taxYear, businessId, mtditid, journey)
+  private def journeyCtx(journey: Journey)     = JourneyAnswersContext(taxYear, nino, businessId, mtditid, journey)
 
   private def downstreamNinoUrl(journey: Journey) = s"/income-tax-self-employment/$taxYear/$businessId/$journey/$nino/answers"
   private def downstreamUrl(journey: Journey)     = s"/income-tax-self-employment/$taxYear/$businessId/$journey/answers"

--- a/test/controllers/actions/SubmittedDataRetrievalActionImplSpec.scala
+++ b/test/controllers/actions/SubmittedDataRetrievalActionImplSpec.scala
@@ -106,7 +106,7 @@ class SubmittedDataRetrievalActionImplSpec extends AnyWordSpecLike with Matchers
     connector.getSubmittedAnswers[JsObject](*)(*, *, *) returns submittedAnswersResult
 
     val repo                                                 = StubSessionRepository()
-    val ctx: OptionalDataRequest[_] => JourneyAnswersContext = req => JourneyAnswersContext(taxYear, businessId, req.mtditid, journey)
+    val ctx: OptionalDataRequest[_] => JourneyAnswersContext = req => JourneyAnswersContext(taxYear, req.nino, businessId, req.mtditid, journey)
     val user = User(mtditid = "1234567890", arn = None, nino = "AA112233A", AffinityGroup.Individual.toString)
 
     val request = OptionalDataRequest[AnyContentAsEmpty.type](FakeRequest(), "userId", user, userAnswers)

--- a/test/controllers/actions/SubmittedDataRetrievalActionProviderImplSpec.scala
+++ b/test/controllers/actions/SubmittedDataRetrievalActionProviderImplSpec.scala
@@ -41,9 +41,10 @@ class SubmittedDataRetrievalActionProviderImplSpec extends AnyWordSpecLike with 
 
   "apply" should {
     "return a SubmittedDataRetrievalActionImpl" in new TestCase {
-      val underTest                                            = new SubmittedDataRetrievalActionProviderImpl(connector, repo)
-      val ctx: OptionalDataRequest[_] => JourneyAnswersContext = req => JourneyAnswersContext(taxYear, businessId, req.mtditid, Journey.TradeDetails)
-      val result                                               = underTest[JsObject](ctx)
+      val underTest = new SubmittedDataRetrievalActionProviderImpl(connector, repo)
+      val ctx: OptionalDataRequest[_] => JourneyAnswersContext =
+        req => JourneyAnswersContext(taxYear, req.nino, businessId, req.mtditid, Journey.TradeDetails)
+      val result = underTest[JsObject](ctx)
       result shouldBe a[SubmittedDataRetrievalActionImpl[_]]
     }
   }

--- a/test/services/SelfEmploymentServiceSpec.scala
+++ b/test/services/SelfEmploymentServiceSpec.scala
@@ -68,7 +68,7 @@ class SelfEmploymentServiceSpec extends SpecBase with ControllerTestScenarioSpec
       mockConnector.getJourneyState(any[BusinessId], any[Journey], any[TaxYear], any[Mtditid])(*, *) returns EitherT
         .rightT[Future, ServiceError](status)
 
-      val result = service.getJourneyStatus(JourneyAnswersContext(taxYear, businessId, mtditid, ExpensesGoodsToSellOrUse)).value.futureValue
+      val result = service.getJourneyStatus(JourneyAnswersContext(taxYear, nino, businessId, mtditid, ExpensesGoodsToSellOrUse)).value.futureValue
 
       result shouldBe status.journeyStatus.asRight
     }
@@ -78,7 +78,7 @@ class SelfEmploymentServiceSpec extends SpecBase with ControllerTestScenarioSpec
     "should save status" in new ServiceWithStubs {
       mockConnector.saveJourneyState(any[JourneyAnswersContext], any[JourneyStatus])(*, *) returns EitherT.rightT[Future, ServiceError](())
       val result = service
-        .setJourneyStatus(JourneyAnswersContext(taxYear, businessId, mtditid, ExpensesGoodsToSellOrUse), JourneyStatus.Completed)
+        .setJourneyStatus(JourneyAnswersContext(taxYear, nino, businessId, mtditid, ExpensesGoodsToSellOrUse), JourneyStatus.Completed)
         .value
         .futureValue
       result shouldBe ().asRight
@@ -115,7 +115,7 @@ class SelfEmploymentServiceSpec extends SpecBase with ControllerTestScenarioSpec
            |""".stripMargin)
       .as[JsObject]
     val userAnswers: UserAnswers = UserAnswers(userAnswersId, userAnswerData)
-    val ctx                      = JourneyAnswersContext(taxYear, businessId, mtditid, ExpensesGoodsToSellOrUse)
+    val ctx                      = JourneyAnswersContext(taxYear, nino, businessId, mtditid, ExpensesGoodsToSellOrUse)
 
     "submit answers to the connector" in new ServiceWithStubs {
       mockConnector.submitAnswers(any, any)(*, *, *) returns EitherT(Future.successful(().asRight[ServiceError]))

--- a/test/stubs/services/AuditServiceStub.scala
+++ b/test/stubs/services/AuditServiceStub.scala
@@ -17,11 +17,11 @@
 package stubs.services
 
 import models.common.JourneyContext
-import play.api.libs.json.{JsObject, Writes}
+import play.api.libs.json.JsObject
 import services.AuditService
 import uk.gov.hmrc.http.HeaderCarrier
 
 case class AuditServiceStub() extends AuditService {
 
-  def sendExplicitAuditEvent[A: Writes](context: JourneyContext, answers: JsObject)(implicit hc: HeaderCarrier): Unit = ()
+  def unsafeSendExplicitCYAAuditEvent(context: JourneyContext, answers: JsObject, wasSuccessful: Boolean)(implicit hc: HeaderCarrier): Unit = ()
 }


### PR DESCRIPTION
I had to add submit our not-ready class 2 NICs to backend to emit the event, it causes a failure right now because we don't have a backend. It will be fixed in the next PR.

It is an example event so PA can start thinking what else we need. There will be a formal process which would take couple of sprints to establish final version of those evens.

There are few tech debts we need to address soon:
- It looks like every audit event needs NINO, which means our context-without-nino and context-with-nino do not make any sense now. We neeed to merge them together, and make sure correct URL (without nino and with nino is applied).
- In good practice I found the standard is to have a flatten structure of answers, right now for simplicity we just use the whole answers. But that will be clearer closer to CIP review