### PR TITLE
[SASS-9575] Append mtditid to generic business IDs for saving nino-specific statuses

### DIFF
--- a/app/connectors/SelfEmploymentConnector.scala
+++ b/app/connectors/SelfEmploymentConnector.scala
@@ -23,7 +23,7 @@ import models.common._
 import models.domain.{ApiResultT, BusinessData, BusinessIncomeSourcesSummary}
 import models.errors.ServiceError
 import models.errors.ServiceError.BusinessNotFoundError
-import models.journeys.{Journey, JourneyNameAndStatus, JourneyStatusData, TaskList}
+import models.journeys.{JourneyNameAndStatus, JourneyStatusData, TaskList}
 import play.api.libs.json.{Reads, Writes}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import utils.EitherTOps.EitherTExtensions

--- a/app/controllers/actions/HopCheckerAction.scala
+++ b/app/controllers/actions/HopCheckerAction.scala
@@ -18,7 +18,7 @@ package controllers.actions
 
 import models.Mode
 import models.common.{BusinessId, TaxYear}
-import models.journeys.Journey
+import models.common.Journey
 import models.requests.DataRequest
 import pages.Page
 import play.api.mvc.ActionFilter

--- a/app/controllers/actions/SubmittedDataRetrievalActionImpl.scala
+++ b/app/controllers/actions/SubmittedDataRetrievalActionImpl.scala
@@ -24,8 +24,8 @@ import models.common.{BusinessId, JourneyContext, UserId}
 import models.database.UserAnswers
 import models.domain.ApiResultT
 import models.errors.ServiceError
-import models.journeys.Journey
-import models.journeys.Journey.NationalInsuranceContributions
+import models.common.Journey
+import models.common.Journey.NationalInsuranceContributions
 import models.requests.OptionalDataRequest
 import play.api.libs.json.{Format, JsObject, Json}
 import play.api.mvc.{ActionTransformer, Request}

--- a/app/controllers/actions/SubmittedDataRetrievalActionProvider.scala
+++ b/app/controllers/actions/SubmittedDataRetrievalActionProvider.scala
@@ -18,15 +18,15 @@ package controllers.actions
 
 import cats.data.EitherT
 import connectors.SelfEmploymentConnector
-import models.common.{JourneyContext, TaxYear}
+import models.common.{Journey, JourneyContext, TaxYear}
 import models.domain.ApiResultT
 import models.errors.ServiceError
+import models.journeys.TaskListWithRequest
 import models.journeys.abroad.SelfEmploymentAbroadAnswers
 import models.journeys.capitalallowances.tailoring.CapitalAllowancesTailoringAnswers
 import models.journeys.expenses.ExpensesTailoringAnswers
 import models.journeys.expenses.goodsToSellOrUse.GoodsToSellOrUseJourneyAnswers
 import models.journeys.income.IncomeJourneyAnswers
-import models.journeys.{Journey, TaskListWithRequest}
 import models.requests.{OptionalDataRequest, TradesJourneyStatuses}
 import play.api.libs.json.Format
 import play.api.mvc.AnyContent

--- a/app/controllers/journeys/abroad/SelfEmploymentAbroadCYAController.scala
+++ b/app/controllers/journeys/abroad/SelfEmploymentAbroadCYAController.scala
@@ -20,8 +20,8 @@ import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierA
 import controllers.handleSubmitAnswersResult
 import controllers.journeys.abroad
 import models.common.{BusinessId, JourneyContextWithNino, TaxYear}
-import models.journeys.Journey
-import models.journeys.Journey.Abroad
+import models.common.Journey
+import models.common.Journey.Abroad
 import models.journeys.abroad.SelfEmploymentAbroadAnswers
 import pages.Page
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/adjustments/profitOrLoss/ProfitOrLossCalculationController.scala
+++ b/app/controllers/journeys/adjustments/profitOrLoss/ProfitOrLossCalculationController.scala
@@ -20,7 +20,7 @@ import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierA
 import models.NormalMode
 import controllers.journeys
 import models.common._
-import models.journeys.Journey.ProfitOrLoss
+import models.common.Journey.ProfitOrLoss
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
@@ -43,11 +43,7 @@ class ProfitOrLossCalculationController @Inject() (override val messagesApi: Mes
 
   def onPageLoad(taxYear: TaxYear, businessId: BusinessId): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
     val summaryList = SummaryListCYA.summaryListOpt(List())
-    Ok(
-      view(
-        request.userType,
-        summaryList,
-        journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, ProfitOrLoss.entryName, NormalMode)))
+    Ok(view(request.userType, summaryList, journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, ProfitOrLoss, NormalMode)))
   }
 
 }

--- a/app/controllers/journeys/capitalallowances/annualInvestmentAllowance/AnnualInvestmentAllowanceCYAController.scala
+++ b/app/controllers/journeys/capitalallowances/annualInvestmentAllowance/AnnualInvestmentAllowanceCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.capitalallowances.annualInvestmentAllowance
 import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction, SubmittedDataRetrievalActionProvider}
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.CapitalAllowancesAnnualInvestmentAllowance
+import models.common.Journey.CapitalAllowancesAnnualInvestmentAllowance
 import models.journeys.capitalallowances.annualInvestmentAllowance.AnnualInvestmentAllowanceAnswers
 import pages.Page
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/capitalallowances/balancingAllowance/BalancingAllowanceCYAController.scala
+++ b/app/controllers/journeys/capitalallowances/balancingAllowance/BalancingAllowanceCYAController.scala
@@ -20,7 +20,7 @@ import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierA
 import controllers.handleSubmitAnswersResult
 import controllers.journeys.capitalallowances.balancingAllowance
 import models.common._
-import models.journeys.Journey.CapitalAllowancesBalancingAllowance
+import models.common.Journey.CapitalAllowancesBalancingAllowance
 import models.journeys.capitalallowances.balancingAllowance.BalancingAllowanceAnswers
 import pages.Page
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/capitalallowances/electricVehicleChargePoints/ElectricVehicleChargePointsCYAController.scala
+++ b/app/controllers/journeys/capitalallowances/electricVehicleChargePoints/ElectricVehicleChargePointsCYAController.scala
@@ -20,7 +20,7 @@ import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierA
 import controllers.handleSubmitAnswersResult
 import controllers.journeys.capitalallowances.electricVehicleChargePoints
 import models.common._
-import models.journeys.Journey.CapitalAllowancesElectricVehicleChargePoints
+import models.common.Journey.CapitalAllowancesElectricVehicleChargePoints
 import models.journeys.capitalallowances.electricVehicleChargePoints.ElectricVehicleChargePointsAnswers
 import pages.Page
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/capitalallowances/specialTaxSites/NewTaxSitesController.scala
+++ b/app/controllers/journeys/capitalallowances/specialTaxSites/NewTaxSitesController.scala
@@ -21,7 +21,7 @@ import controllers.{journeys, redirectJourneyRecovery}
 import forms.standard.BooleanFormProvider
 import models.NormalMode
 import models.common._
-import models.journeys.Journey.CapitalAllowancesSpecialTaxSites
+import models.common.Journey.CapitalAllowancesSpecialTaxSites
 import models.journeys.capitalallowances.specialTaxSites.NewSpecialTaxSite.returnTotalIfMultipleSites
 import models.journeys.capitalallowances.specialTaxSites.SpecialTaxSitesAnswers.removeIncompleteSites
 import pages.capitalallowances.specialTaxSites._

--- a/app/controllers/journeys/capitalallowances/specialTaxSites/SpecialTaxSitesCYAController.scala
+++ b/app/controllers/journeys/capitalallowances/specialTaxSites/SpecialTaxSitesCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.capitalallowances.specialTaxSites
 import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction, SubmittedDataRetrievalActionProvider}
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.CapitalAllowancesSpecialTaxSites
+import models.common.Journey.CapitalAllowancesSpecialTaxSites
 import models.journeys.capitalallowances.specialTaxSites.SpecialTaxSitesAnswers
 import pages.Page
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsCYAController.scala
+++ b/app/controllers/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsCYAController.scala
@@ -20,7 +20,7 @@ import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierA
 import controllers.handleSubmitAnswersResult
 import controllers.journeys.capitalallowances.structuresBuildingsAllowance
 import models.common._
-import models.journeys.Journey.CapitalAllowancesStructuresBuildings
+import models.common.Journey.CapitalAllowancesStructuresBuildings
 import models.journeys.capitalallowances.structuresBuildingsAllowance.NewStructuresBuildingsAnswers
 import pages.Page
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/capitalallowances/tailoring/CapitalAllowanceCYAController.scala
+++ b/app/controllers/journeys/capitalallowances/tailoring/CapitalAllowanceCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.capitalallowances.tailoring
 import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction, SubmittedDataRetrievalActionProvider}
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.CapitalAllowancesTailoring
+import models.common.Journey.CapitalAllowancesTailoring
 import models.journeys.capitalallowances.tailoring.CapitalAllowancesTailoringAnswers
 import pages.Page
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/capitalallowances/writingDownAllowance/WritingDownAllowanceCYAController.scala
+++ b/app/controllers/journeys/capitalallowances/writingDownAllowance/WritingDownAllowanceCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.capitalallowances.writingDownAllowance
 import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction, SubmittedDataRetrievalActionProvider}
 import controllers.handleSubmitAnswersResult
 import models.common.{BusinessId, JourneyContextWithNino, TaxYear}
-import models.journeys.Journey.CapitalAllowancesWritingDownAllowance
+import models.common.Journey.CapitalAllowancesWritingDownAllowance
 import models.journeys.capitalallowances.writingDownAllowance.WritingDownAllowanceAnswers
 import pages.Page
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/capitalallowances/zeroEmissionCars/ZeroEmissionCarsCYAController.scala
+++ b/app/controllers/journeys/capitalallowances/zeroEmissionCars/ZeroEmissionCarsCYAController.scala
@@ -20,7 +20,7 @@ import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierA
 import controllers.handleSubmitAnswersResult
 import controllers.journeys.capitalallowances.zeroEmissionCars
 import models.common._
-import models.journeys.Journey.CapitalAllowancesZeroEmissionCars
+import models.common.Journey.CapitalAllowancesZeroEmissionCars
 import models.journeys.capitalallowances.zeroEmissionCars.ZeroEmissionCarsAnswers
 import pages.Page
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZeroEmissionGoodsVehicleCYAController.scala
+++ b/app/controllers/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZeroEmissionGoodsVehicleCYAController.scala
@@ -20,7 +20,7 @@ import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierA
 import controllers.handleSubmitAnswersResult
 import controllers.journeys.capitalallowances.zeroEmissionGoodsVehicle
 import models.common._
-import models.journeys.Journey.CapitalAllowancesZeroEmissionGoodsVehicle
+import models.common.Journey.CapitalAllowancesZeroEmissionGoodsVehicle
 import models.journeys.capitalallowances.zeroEmissionGoodsVehicle.ZeroEmissionGoodsVehicleAnswers
 import pages.Page
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/advertisingOrMarketing/AdvertisingCYAController.scala
+++ b/app/controllers/journeys/expenses/advertisingOrMarketing/AdvertisingCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.expenses.advertisingOrMarketing
 import controllers.actions._
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.ExpensesAdvertisingOrMarketing
+import models.common.Journey.ExpensesAdvertisingOrMarketing
 import models.journeys.expenses.advertisingOrMarketing.AdvertisingOrMarketingJourneyAnswers
 import pages.expenses.advertisingOrMarketing.AdvertisingOrMarketingCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/construction/ConstructionIndustryCYAController.scala
+++ b/app/controllers/journeys/expenses/construction/ConstructionIndustryCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.expenses.construction
 import controllers.actions._
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.ExpensesConstruction
+import models.common.Journey.ExpensesConstruction
 import models.journeys.expenses.construction.ConstructionJourneyAnswers
 import pages.expenses.construction.ConstructionIndustryCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/depreciation/DepreciationCYAController.scala
+++ b/app/controllers/journeys/expenses/depreciation/DepreciationCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.expenses.depreciation
 import controllers.actions._
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.ExpensesDepreciation
+import models.common.Journey.ExpensesDepreciation
 import models.journeys.expenses.depreciation.DepreciationJourneyAnswers
 import pages.expenses.depreciation.DepreciationCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/entertainment/EntertainmentCYAController.scala
+++ b/app/controllers/journeys/expenses/entertainment/EntertainmentCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.expenses.entertainment
 import controllers.actions._
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.ExpensesEntertainment
+import models.common.Journey.ExpensesEntertainment
 import models.journeys.expenses.entertainment.EntertainmentJourneyAnswers
 import pages.expenses.entertainment.EntertainmentCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/financialCharges/FinancialChargesCYAController.scala
+++ b/app/controllers/journeys/expenses/financialCharges/FinancialChargesCYAController.scala
@@ -20,7 +20,7 @@ import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierA
 import controllers.handleSubmitAnswersResult
 import controllers.journeys.expenses.financialCharges.routes._
 import models.common.{BusinessId, JourneyContextWithNino, TaxYear}
-import models.journeys.Journey.ExpensesFinancialCharges
+import models.common.Journey.ExpensesFinancialCharges
 import models.journeys.expenses.financialCharges.FinancialChargesJourneyAnswers
 import pages.expenses.financialCharges.FinancialChargesCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/goodsToSellOrUse/GoodsToSellOrUseCYAController.scala
+++ b/app/controllers/journeys/expenses/goodsToSellOrUse/GoodsToSellOrUseCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.expenses.goodsToSellOrUse
 import controllers.actions._
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.ExpensesGoodsToSellOrUse
+import models.common.Journey.ExpensesGoodsToSellOrUse
 import models.journeys.expenses.goodsToSellOrUse.GoodsToSellOrUseJourneyAnswers
 import pages.expenses.goodsToSellOrUse.GoodsToSellOrUseCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/interest/InterestCYAController.scala
+++ b/app/controllers/journeys/expenses/interest/InterestCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.expenses.interest
 import controllers.actions._
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.ExpensesInterest
+import models.common.Journey.ExpensesInterest
 import models.journeys.expenses.interest.InterestJourneyAnswers
 import pages.expenses.interest.InterestCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/irrecoverableDebts/IrrecoverableDebtsCYAController.scala
+++ b/app/controllers/journeys/expenses/irrecoverableDebts/IrrecoverableDebtsCYAController.scala
@@ -19,8 +19,8 @@ package controllers.journeys.expenses.irrecoverableDebts
 import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction, SubmittedDataRetrievalActionProvider}
 import controllers.handleSubmitAnswersResult
 import models.common.{BusinessId, JourneyContextWithNino, TaxYear}
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesIrrecoverableDebts
+import models.common.Journey
+import models.common.Journey.ExpensesIrrecoverableDebts
 import models.journeys.expenses.irrecoverableDebts.IrrecoverableDebtsJourneyAnswers
 import pages.expenses.irrecoverableDebts.IrrecoverableDebtsCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/officeSupplies/OfficeSuppliesCYAController.scala
+++ b/app/controllers/journeys/expenses/officeSupplies/OfficeSuppliesCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.expenses.officeSupplies
 import controllers.actions._
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.ExpensesOfficeSupplies
+import models.common.Journey.ExpensesOfficeSupplies
 import models.journeys.expenses.officeSupplies.OfficeSuppliesJourneyAnswers
 import pages.expenses.officeSupplies.OfficeSuppliesCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/otherExpenses/OtherExpensesCYAController.scala
+++ b/app/controllers/journeys/expenses/otherExpenses/OtherExpensesCYAController.scala
@@ -20,7 +20,7 @@ import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierA
 import controllers.handleSubmitAnswersResult
 import controllers.journeys.expenses.otherExpenses.routes.OtherExpensesCYAController
 import models.common.{BusinessId, JourneyContextWithNino, TaxYear}
-import models.journeys.Journey.ExpensesOtherExpenses
+import models.common.Journey.ExpensesOtherExpenses
 import models.journeys.expenses.otherExpenses.OtherExpensesJourneyAnswers
 import pages.expenses.otherExpenses.OtherExpensesCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/professionalFees/ProfessionalFeesCYAController.scala
+++ b/app/controllers/journeys/expenses/professionalFees/ProfessionalFeesCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.expenses.professionalFees
 import controllers.actions._
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.ExpensesProfessionalFees
+import models.common.Journey.ExpensesProfessionalFees
 import models.journeys.expenses.professionalFees.ProfessionalFeesJourneyAnswers
 import pages.expenses.professionalFees.ProfessionalFeesCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/repairsandmaintenance/RepairsAndMaintenanceCostsCYAController.scala
+++ b/app/controllers/journeys/expenses/repairsandmaintenance/RepairsAndMaintenanceCostsCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.expenses.repairsandmaintenance
 import controllers.actions._
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.ExpensesRepairsAndMaintenance
+import models.common.Journey.ExpensesRepairsAndMaintenance
 import models.journeys.expenses.repairsandmaintenance.RepairsAndMaintenanceCostsJourneyAnswers
 import pages.expenses.repairsandmaintenance.RepairsAndMaintenanceCostsCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/staffCosts/StaffCostsCYAController.scala
+++ b/app/controllers/journeys/expenses/staffCosts/StaffCostsCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.expenses.staffCosts
 import controllers.actions._
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.ExpensesStaffCosts
+import models.common.Journey.ExpensesStaffCosts
 import models.journeys.expenses.staffCosts.StaffCostsJourneyAnswers
 import pages.expenses.staffCosts.StaffCostsCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/tailoring/ExpensesCategoriesController.scala
+++ b/app/controllers/journeys/expenses/tailoring/ExpensesCategoriesController.scala
@@ -22,7 +22,7 @@ import controllers.actions._
 import forms.expenses.tailoring.ExpensesCategoriesFormProvider
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
+import models.common.Journey
 import models.journeys.expenses.ExpensesTailoring
 import models.journeys.expenses.ExpensesTailoring.{IndividualCategories, NoExpenses, TotalAmount, tailoringList}
 import models.{Mode, NormalMode}

--- a/app/controllers/journeys/expenses/tailoring/ExpensesTailoringCYAController.scala
+++ b/app/controllers/journeys/expenses/tailoring/ExpensesTailoringCYAController.scala
@@ -21,8 +21,8 @@ import controllers.handleSubmitAnswersResult
 import controllers.journeys.expenses.tailoring
 import models.CheckMode
 import models.common._
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesTailoring
+import models.common.Journey
+import models.common.Journey.ExpensesTailoring
 import models.journeys.expenses.ExpensesTailoring.{IndividualCategories, NoExpenses, TotalAmount}
 import models.journeys.expenses.ExpensesTailoringAnswers
 import models.journeys.expenses.ExpensesTailoringAnswers._

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/AdvertisingOrMarketingController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/AdvertisingOrMarketingController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.EnumerableFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear, UserType}
-import models.journeys.Journey
+import models.common.Journey
 import models.journeys.expenses.individualCategories.AdvertisingOrMarketing
 import models.journeys.expenses.individualCategories.AdvertisingOrMarketing.enumerable
 import navigation.ExpensesTailoringNavigator

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/DepreciationController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/DepreciationController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.BooleanFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear}
-import models.journeys.Journey
+import models.common.Journey
 import navigation.ExpensesTailoringNavigator
 import pages.expenses.tailoring.individualCategories.DepreciationPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/DisallowableInterestController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/DisallowableInterestController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.BooleanFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear}
-import models.journeys.Journey
+import models.common.Journey
 import navigation.ExpensesTailoringNavigator
 import pages.expenses.tailoring.individualCategories.DisallowableInterestPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/DisallowableIrrecoverableDebtsController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/DisallowableIrrecoverableDebtsController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.BooleanFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear}
-import models.journeys.Journey
+import models.common.Journey
 import navigation.ExpensesTailoringNavigator
 import pages.expenses.tailoring.individualCategories.DisallowableIrrecoverableDebtsPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/DisallowableOtherFinancialChargesController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/DisallowableOtherFinancialChargesController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.BooleanFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear}
-import models.journeys.Journey
+import models.common.Journey
 import navigation.ExpensesTailoringNavigator
 import pages.expenses.tailoring.individualCategories.DisallowableOtherFinancialChargesPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/DisallowableProfessionalFeesController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/DisallowableProfessionalFeesController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.BooleanFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear}
-import models.journeys.Journey
+import models.common.Journey
 import navigation.ExpensesTailoringNavigator
 import pages.expenses.tailoring.individualCategories.DisallowableProfessionalFeesPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/DisallowableStaffCostsController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/DisallowableStaffCostsController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.BooleanFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear}
-import models.journeys.Journey
+import models.common.Journey
 import navigation.ExpensesTailoringNavigator
 import pages.expenses.tailoring.individualCategories.DisallowableStaffCostsPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/DisallowableSubcontractorCostsController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/DisallowableSubcontractorCostsController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.BooleanFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear}
-import models.journeys.Journey
+import models.common.Journey
 import navigation.ExpensesTailoringNavigator
 import pages.expenses.tailoring.individualCategories.DisallowableSubcontractorCostsPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/EntertainmentCostsController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/EntertainmentCostsController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.BooleanFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear}
-import models.journeys.Journey
+import models.common.Journey
 import navigation.ExpensesTailoringNavigator
 import pages.expenses.tailoring.individualCategories.EntertainmentCostsPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/FinancialExpensesController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/FinancialExpensesController.scala
@@ -23,7 +23,7 @@ import forms.expenses.tailoring.individualCategories.FinancialExpensesFormProvid
 import models.Mode
 import models.common.{BusinessId, TaxYear}
 import models.database.UserAnswers
-import models.journeys.Journey
+import models.common.Journey
 import models.journeys.expenses.individualCategories.FinancialExpenses
 import models.journeys.expenses.individualCategories.FinancialExpenses.{Interest, IrrecoverableDebts, OtherFinancialCharges}
 import navigation.ExpensesTailoringNavigator

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/GoodsToSellOrUseController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/GoodsToSellOrUseController.scala
@@ -22,7 +22,7 @@ import controllers.returnAccountingType
 import forms.standard.EnumerableFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear, UserType}
-import models.journeys.Journey
+import models.common.Journey
 import models.journeys.expenses.individualCategories.GoodsToSellOrUse
 import models.journeys.expenses.individualCategories.GoodsToSellOrUse.enumerable
 import navigation.ExpensesTailoringNavigator

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/OfficeSuppliesController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/OfficeSuppliesController.scala
@@ -22,7 +22,7 @@ import controllers.returnAccountingType
 import forms.standard.EnumerableFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear, UserType}
-import models.journeys.Journey
+import models.common.Journey
 import models.journeys.expenses.individualCategories.OfficeSupplies
 import models.journeys.expenses.individualCategories.OfficeSupplies.enumerable
 import navigation.ExpensesTailoringNavigator

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/OtherExpensesController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/OtherExpensesController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.EnumerableFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear, UserType}
-import models.journeys.Journey
+import models.common.Journey
 import models.journeys.expenses.individualCategories.OtherExpenses
 import models.journeys.expenses.individualCategories.OtherExpenses.enumerable
 import navigation.ExpensesTailoringNavigator

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/ProfessionalServiceExpensesController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/ProfessionalServiceExpensesController.scala
@@ -23,7 +23,7 @@ import forms.expenses.tailoring.individualCategories.ProfessionalServiceExpenses
 import models.Mode
 import models.common.{BusinessId, TaxYear}
 import models.database.UserAnswers
-import models.journeys.Journey
+import models.common.Journey
 import models.journeys.expenses.individualCategories.ProfessionalServiceExpenses
 import models.journeys.expenses.individualCategories.ProfessionalServiceExpenses.{Construction, ProfessionalFees, Staff}
 import navigation.ExpensesTailoringNavigator

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/RepairsAndMaintenanceController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/RepairsAndMaintenanceController.scala
@@ -22,7 +22,7 @@ import controllers.returnAccountingType
 import forms.standard.EnumerableFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear, UserType}
-import models.journeys.Journey
+import models.common.Journey
 import models.journeys.expenses.individualCategories.RepairsAndMaintenance
 import models.journeys.expenses.individualCategories.RepairsAndMaintenance.enumerable
 import navigation.ExpensesTailoringNavigator

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/TravelForWorkController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/TravelForWorkController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.EnumerableFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear, UserType}
-import models.journeys.Journey
+import models.common.Journey
 import models.journeys.expenses.individualCategories.TravelForWork
 import models.journeys.expenses.individualCategories.TravelForWork.enumerable
 import navigation.ExpensesTailoringNavigator

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/WorkFromBusinessPremisesController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/WorkFromBusinessPremisesController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.EnumerableFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear, UserType}
-import models.journeys.Journey
+import models.common.Journey
 import models.journeys.expenses.individualCategories.WorkFromBusinessPremises
 import models.journeys.expenses.individualCategories.WorkFromBusinessPremises.enumerable
 import navigation.ExpensesTailoringNavigator

--- a/app/controllers/journeys/expenses/tailoring/individualCategories/WorkFromHomeController.scala
+++ b/app/controllers/journeys/expenses/tailoring/individualCategories/WorkFromHomeController.scala
@@ -21,7 +21,7 @@ import controllers.journeys.fillForm
 import forms.standard.BooleanFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear}
-import models.journeys.Journey
+import models.common.Journey
 import navigation.ExpensesTailoringNavigator
 import pages.expenses.tailoring.individualCategories.WorkFromHomePage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/tailoring/simplifiedExpenses/TotalExpensesController.scala
+++ b/app/controllers/journeys/expenses/tailoring/simplifiedExpenses/TotalExpensesController.scala
@@ -22,7 +22,7 @@ import controllers.journeys.fillForm
 import forms.standard.CurrencyFormProvider
 import models.Mode
 import models.common.{BusinessId, TaxYear, UserType}
-import models.journeys.Journey
+import models.common.Journey
 import navigation.ExpensesTailoringNavigator
 import pages.expenses.tailoring.simplifiedExpenses.TotalExpensesPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/expenses/workplaceRunningCosts/WorkplaceRunningCostsCYAController.scala
+++ b/app/controllers/journeys/expenses/workplaceRunningCosts/WorkplaceRunningCostsCYAController.scala
@@ -19,7 +19,7 @@ package controllers.journeys.expenses.workplaceRunningCosts
 import controllers.actions._
 import controllers.handleSubmitAnswersResult
 import models.common._
-import models.journeys.Journey.ExpensesWorkplaceRunningCosts
+import models.common.Journey.ExpensesWorkplaceRunningCosts
 import models.journeys.expenses.workplaceRunningCosts.WorkplaceRunningCostsJourneyAnswers
 import pages.expenses.workplaceRunningCosts.WorkplaceRunningCostsCYAPage
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/journeys/income/IncomeCYAController.scala
+++ b/app/controllers/journeys/income/IncomeCYAController.scala
@@ -20,8 +20,8 @@ import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierA
 import controllers.handleSubmitAnswersResult
 import models.common._
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.Income
+import models.common.Journey
+import models.common.Journey.Income
 import models.journeys.income.IncomeJourneyAnswers
 import play.api.i18n.{I18nSupport, Messages, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}

--- a/app/controllers/journeys/nics/NICsCYAController.scala
+++ b/app/controllers/journeys/nics/NICsCYAController.scala
@@ -22,7 +22,7 @@ import models.CheckMode
 import models.common.BusinessId.nationalInsuranceContributions
 import models.common.{BusinessId, JourneyContextWithNino, TaxYear}
 import models.domain.BusinessData
-import models.journeys.Journey.NationalInsuranceContributions
+import models.common.Journey.NationalInsuranceContributions
 import models.journeys.nics.NICsJourneyAnswers
 import pages.Page
 import pages.nics._

--- a/app/controllers/journeys/prepop/AdjustmentsSummaryController.scala
+++ b/app/controllers/journeys/prepop/AdjustmentsSummaryController.scala
@@ -18,7 +18,7 @@ package controllers.journeys.prepop
 
 import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction, SubmittedDataRetrievalActionProvider}
 import models.common._
-import models.journeys.Journey.AdjustmentsPrepop
+import models.common.Journey.AdjustmentsPrepop
 import models.journeys.adjustments.AdjustmentsPrepopAnswers
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}

--- a/app/controllers/journeys/prepop/BusinessIncomeSummaryController.scala
+++ b/app/controllers/journeys/prepop/BusinessIncomeSummaryController.scala
@@ -18,7 +18,7 @@ package controllers.journeys.prepop
 
 import controllers.actions.{DataRequiredAction, DataRetrievalAction, IdentifierAction, SubmittedDataRetrievalActionProvider}
 import models.common._
-import models.journeys.Journey.IncomePrepop
+import models.common.Journey.IncomePrepop
 import models.journeys.income.IncomePrepopAnswers
 import pages.prepop.{IncomeOtherAmount, IncomeTurnoverAmount}
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/controllers/package.scala
+++ b/app/controllers/package.scala
@@ -20,7 +20,7 @@ import models.NormalMode
 import models.common.{AccountingType, BusinessId, JourneyContext, TaxYear}
 import models.domain.{ApiResultT, BusinessData}
 import models.errors.ServiceError
-import models.journeys.Journey
+import models.common.Journey
 import models.requests.DataRequest
 import play.api.Logger
 import play.api.mvc.Result
@@ -35,7 +35,7 @@ package object controllers extends Logging {
   def redirectJourneyRecovery(): Result = Redirect(standard.routes.JourneyRecoveryController.onPageLoad())
 
   private def redirectJourneyCompletedState(taxYear: TaxYear, businessId: BusinessId, journey: Journey): Result = Redirect(
-    journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, journey.entryName, NormalMode)
+    journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, journey, NormalMode)
   )
 
   def returnAccountingType(businessId: BusinessId)(implicit request: DataRequest[_]): AccountingType =

--- a/app/models/audit/SelfEmploymentAuditEvent.scala
+++ b/app/models/audit/SelfEmploymentAuditEvent.scala
@@ -17,7 +17,7 @@
 package models.audit
 
 import models.common.{JourneyStatus, Mtditid, Nino, TaxYear}
-import models.journeys.Journey
+import models.common.Journey
 import play.api.libs.json.{JsObject, Json, OWrites, Writes}
 
 sealed trait SelfEmploymentAuditEvent

--- a/app/models/common/BusinessId.scala
+++ b/app/models/common/BusinessId.scala
@@ -16,6 +16,8 @@
 
 package models.common
 
+import models.common.Journey
+import models.common.Journey.{NationalInsuranceContributions, TradeDetails}
 import play.api.data.Forms.text
 import play.api.data.Mapping
 import play.api.libs.json.{Format, Json}
@@ -23,6 +25,11 @@ import play.api.mvc.PathBindable
 
 final case class BusinessId(value: String) extends AnyVal {
   override def toString: String = value
+
+  def checkToUpdateBusinessIdWithMtditid(journey: Journey, mtditid: Mtditid): BusinessId = journey match {
+    case TradeDetails | NationalInsuranceContributions => BusinessId(s"$value-${mtditid.value}")
+    case _                                             => this
+  }
 }
 
 object BusinessId {

--- a/app/models/common/Journey.scala
+++ b/app/models/common/Journey.scala
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package models.journeys
+package models.common
 
 import controllers.journeys.expenses
 import enumeratum._
 import models.NormalMode
-import models.common.{BusinessId, PageName, TaxYear}
 import pages.QuestionPage
 import pages.abroad.SelfEmploymentAbroadPage
 import pages.adjustments.profitOrLoss._

--- a/app/models/common/JourneyContext.scala
+++ b/app/models/common/JourneyContext.scala
@@ -16,7 +16,7 @@
 
 package models.common
 
-import models.journeys.Journey
+import models.common.Journey
 import models.requests.{DataRequest, NinoDataRequest}
 import play.api.mvc.AnyContent
 

--- a/app/models/common/JourneyStatus.scala
+++ b/app/models/common/JourneyStatus.scala
@@ -17,7 +17,7 @@
 package models.common
 
 import enumeratum._
-import models.journeys.{Journey, JourneyNameAndStatus}
+import models.journeys.JourneyNameAndStatus
 
 sealed abstract class JourneyStatus(override val entryName: String) extends EnumEntry {
   override def toString: String = entryName

--- a/app/models/journeys/JourneyNameAndStatus.scala
+++ b/app/models/journeys/JourneyNameAndStatus.scala
@@ -16,7 +16,7 @@
 
 package models.journeys
 
-import models.common.JourneyStatus
+import models.common.{Journey, JourneyStatus}
 import play.api.libs.json.{Json, OFormat}
 
 final case class JourneyNameAndStatus(name: Journey, journeyStatus: JourneyStatus)

--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -20,7 +20,7 @@ import controllers.actions.AuthenticatedIdentifierAction.User
 import controllers.standard
 import models.common._
 import models.database.UserAnswers
-import models.journeys.Journey
+import models.common.Journey
 import pages.{TradeAccountingType, TradingNameKey}
 import play.api.libs.json.Reads
 import play.api.mvc.Results.Redirect

--- a/app/models/requests/TradesJourneyStatuses.scala
+++ b/app/models/requests/TradesJourneyStatuses.scala
@@ -19,12 +19,12 @@ package models.requests
 import models.common.JourneyStatus.NotStarted
 import models.common._
 import models.database.UserAnswers
-import models.journeys.{Journey, JourneyNameAndStatus}
+import models.journeys.JourneyNameAndStatus
 import play.api.i18n.Messages
 import play.api.libs.json.{Json, OFormat}
 import viewmodels.journeys.taskList.PrepopTradeJourneyStatusesViewModel.buildPrepopSummaryList
-import viewmodels.journeys.taskList.{PrepopTradeJourneyStatusesViewModel, TradeJourneyStatusesViewModel}
 import viewmodels.journeys.taskList.TradeJourneyStatusesViewModel.buildSummaryList
+import viewmodels.journeys.taskList.{PrepopTradeJourneyStatusesViewModel, TradeJourneyStatusesViewModel}
 
 case class TradesJourneyStatuses(businessId: BusinessId,
                                  tradingName: Option[TradingName],

--- a/app/navigation/ExpensesTailoringNavigator.scala
+++ b/app/navigation/ExpensesTailoringNavigator.scala
@@ -22,7 +22,7 @@ import controllers.standard.routes._
 import controllers.{journeys, standard}
 import models.common.{BusinessId, TaxYear}
 import models.database.UserAnswers
-import models.journeys.Journey.ExpensesTailoring
+import models.common.Journey.ExpensesTailoring
 import models.journeys.expenses.ExpensesTailoring._
 import models.journeys.expenses.individualCategories.FinancialExpenses.{Interest, IrrecoverableDebts, NoFinancialExpenses, OtherFinancialCharges}
 import models.journeys.expenses.individualCategories.ProfessionalServiceExpenses.{Construction, No, ProfessionalFees, Staff}
@@ -163,9 +163,7 @@ class ExpensesTailoringNavigator @Inject() {
     case OtherExpensesPage => _ => (taxYear, businessId) => tailoring.routes.ExpensesTailoringCYAController.onPageLoad(taxYear, businessId)
 
     case ExpensesTailoringCYAPage =>
-      _ =>
-        (taxYear, businessId) =>
-          journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, ExpensesTailoring.toString, NormalMode)
+      _ => (taxYear, businessId) => journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, ExpensesTailoring, NormalMode)
 
     case _ => _ => (_, _) => JourneyRecoveryController.onPageLoad()
   }

--- a/app/pages/prepop/PrepopCheckYourSelfEmploymentDetailsPage.scala
+++ b/app/pages/prepop/PrepopCheckYourSelfEmploymentDetailsPage.scala
@@ -19,7 +19,7 @@ package pages.prepop
 import controllers.journeys.routes
 import models.NormalMode
 import models.common.{BusinessId, TaxYear}
-import models.journeys.Journey.BusinessDetailsPrepop
+import models.common.Journey.BusinessDetailsPrepop
 import pages.Page
 import play.api.mvc.Call
 
@@ -28,5 +28,5 @@ case object PrepopCheckYourSelfEmploymentDetailsPage extends Page {
   override def toString: String = "checkYourSelfEmploymentDetails"
 
   def nextPage(taxYear: TaxYear, businessId: BusinessId): Call =
-    routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, BusinessDetailsPrepop.entryName, NormalMode)
+    routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, BusinessDetailsPrepop, NormalMode)
 }

--- a/app/pages/tradeDetails/SelfEmploymentSummaryPage.scala
+++ b/app/pages/tradeDetails/SelfEmploymentSummaryPage.scala
@@ -19,7 +19,7 @@ package pages.tradeDetails
 import controllers.journeys.routes
 import models.NormalMode
 import models.common.{BusinessId, TaxYear}
-import models.journeys.Journey.TradeDetails
+import models.common.Journey.TradeDetails
 import pages.Page
 import play.api.mvc.Call
 
@@ -27,5 +27,5 @@ case object SelfEmploymentSummaryPage extends Page {
   override def toString: String = "selfEmploymentSummary"
 
   def nextPage(taxYear: TaxYear, businessId: BusinessId): Call =
-    routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, TradeDetails.toString, NormalMode)
+    routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, TradeDetails, NormalMode)
 }

--- a/app/services/AuditService.scala
+++ b/app/services/AuditService.scala
@@ -18,8 +18,8 @@ package services
 
 import models.audit.{AuditEventType, AuditSectionName, CYAnswersAuditEvent}
 import models.common.JourneyContext
-import models.journeys.Journey
-import models.journeys.Journey.NationalInsuranceContributions
+import models.common.Journey
+import models.common.Journey.NationalInsuranceContributions
 import play.api.libs.json.JsObject
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector

--- a/app/viewmodels/journeys/package.scala
+++ b/app/viewmodels/journeys/package.scala
@@ -17,9 +17,9 @@
 package viewmodels
 
 import models.common.JourneyStatus.{CannotStartYet, CheckOurRecords, Completed, InProgress, NotStarted}
-import models.common.{BusinessId, JourneyStatus}
+import models.common.{BusinessId, Journey, JourneyStatus}
 import models.database.UserAnswers
-import models.journeys.{Journey, JourneyNameAndStatus}
+import models.journeys.JourneyNameAndStatus
 import models.requests.TradesJourneyStatuses
 import pages.OneQuestionPage
 import play.api.libs.json.Reads

--- a/app/viewmodels/journeys/taskList/CapitalAllowancesTasklist.scala
+++ b/app/viewmodels/journeys/taskList/CapitalAllowancesTasklist.scala
@@ -20,10 +20,10 @@ import cats.implicits.catsSyntaxOptionId
 import controllers.journeys.capitalallowances
 import models.NormalMode
 import models.common.AccountingType.Cash
+import models.common.Journey._
 import models.common.JourneyStatus.Completed
 import models.common.{BusinessId, JourneyStatus, TaxYear}
 import models.database.UserAnswers
-import models.journeys.Journey._
 import models.journeys.capitalallowances.tailoring.CapitalAllowances
 import models.requests.TradesJourneyStatuses
 import pages.capitalallowances.tailoring.SelectCapitalAllowancesPage

--- a/app/viewmodels/journeys/taskList/ExpensesTasklist.scala
+++ b/app/viewmodels/journeys/taskList/ExpensesTasklist.scala
@@ -18,11 +18,10 @@ package viewmodels.journeys.taskList
 
 import controllers.journeys.expenses
 import models.NormalMode
+import models.common.Journey._
 import models.common.JourneyStatus.{CheckOurRecords, Completed, InProgress, NotStarted}
-import models.common.{BusinessId, JourneyStatus, TaxYear}
+import models.common.{BusinessId, Journey, JourneyStatus, TaxYear}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey._
 import models.journeys.expenses.individualCategories._
 import models.journeys.income.TradingAllowance
 import models.requests.TradesJourneyStatuses

--- a/app/viewmodels/journeys/taskList/NationalInsuranceContributionsViewModel.scala
+++ b/app/viewmodels/journeys/taskList/NationalInsuranceContributionsViewModel.scala
@@ -19,8 +19,8 @@ package viewmodels.journeys.taskList
 import cats.implicits.catsSyntaxOptionId
 import controllers.journeys.nics
 import models.NormalMode
+import models.common.Journey.{NationalInsuranceContributions, ProfitOrLoss}
 import models.common.{JourneyStatus, TaxYear}
-import models.journeys.Journey.{NationalInsuranceContributions, ProfitOrLoss}
 import models.journeys.JourneyNameAndStatus
 import models.journeys.nics.NicClassExemption.{Class2, Class4, NotEligible}
 import models.journeys.nics.TaxableProfitAndLoss

--- a/app/viewmodels/journeys/taskList/PrepopTradeJourneyStatusesViewModel.scala
+++ b/app/viewmodels/journeys/taskList/PrepopTradeJourneyStatusesViewModel.scala
@@ -18,10 +18,9 @@ package viewmodels.journeys.taskList
 
 import controllers.journeys.income
 import models._
+import models.common.Journey._
 import models.common.JourneyStatus.CannotStartYet
-import models.common.{BusinessId, JourneyStatus, TaxYear, TradingName, TypeOfBusiness}
-import models.journeys.Journey
-import models.journeys.Journey._
+import models.common._
 import models.requests.TradesJourneyStatuses
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent

--- a/app/viewmodels/journeys/taskList/TradeJourneyStatusesViewModel.scala
+++ b/app/viewmodels/journeys/taskList/TradeJourneyStatusesViewModel.scala
@@ -21,8 +21,8 @@ import models._
 import models.common.JourneyStatus.CannotStartYet
 import models.common._
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey._
+import models.common.Journey
+import models.common.Journey._
 import models.requests.TradesJourneyStatuses
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent

--- a/app/views/journeys/SectionCompletedStateView.scala.html
+++ b/app/views/journeys/SectionCompletedStateView.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.common.{BusinessId, TaxYear}
-@import models.journeys.Journey
+@import models.common.Journey
 @import views.html.components._
 
 @this(
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("sectionCompletedState.title"))) {
 
-    @formHelper(action = controllers.journeys.routes.SectionCompletedStateController.onSubmit(taxYear, businessId, journey.entryName, mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.journeys.routes.SectionCompletedStateController.onSubmit(taxYear, businessId, journey, mode), Symbol("autoComplete") -> "off") {
 
         @errorSummarySection(form, errorLinkOverrides = Map("value" -> "value_0"))
 

--- a/app/views/journeys/prepop/AdjustmentsSummaryView.scala.html
+++ b/app/views/journeys/prepop/AdjustmentsSummaryView.scala.html
@@ -16,7 +16,7 @@
 
 @import controllers.journeys
 @import models.common.{BusinessId, TaxYear, UserType}
-@import models.journeys.Journey.AdjustmentsPrepop
+@import models.common.Journey.AdjustmentsPrepop
 @import views.html.components.{Button, CaptionWithTaxYear, Heading, Subheading}
 
 @this(layout: templates.Layout,
@@ -39,7 +39,7 @@
     @govukTable(adjustmentsTable)
 
     <div class="govuk-!-margin-top-7">
-        @button(journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, AdjustmentsPrepop.entryName, NormalMode).url, "site.continue")
+        @button(journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, AdjustmentsPrepop, NormalMode).url, "site.continue")
     </div>
 
 }

--- a/app/views/journeys/prepop/BusinessIncomeSummaryView.scala.html
+++ b/app/views/journeys/prepop/BusinessIncomeSummaryView.scala.html
@@ -16,7 +16,7 @@
 
 @import controllers.journeys
 @import models.common.{BusinessId, TaxYear, UserType}
-@import models.journeys.Journey.IncomePrepop
+@import models.common.Journey.IncomePrepop
 @import views.html.components.{Button, CaptionWithTaxYear, Heading, Subheading}
 
 @this(layout: templates.Layout,
@@ -40,7 +40,7 @@
     @govukTable(incomeTable)
 
     <div class="govuk-!-margin-top-7">
-        @button(journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, IncomePrepop.entryName, NormalMode).url, "site.continue")
+        @button(journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, IncomePrepop, NormalMode).url, "site.continue")
     </div>
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -25,10 +25,10 @@ GET         /unauthorised                                                       
 GET         /:taxYear/task-list                                                     controllers.journeys.TaskListController.onPageLoad(taxYear: TaxYear)
 GET         /:taxYear/task-list-prepop                                              controllers.journeys.PrepopTaskListController.onPageLoad(taxYear: TaxYear)
 
-GET         /:taxYear/:businessId/:journey/details/completed-section                controllers.journeys.SectionCompletedStateController.onPageLoad(taxYear: TaxYear, businessId: BusinessId, journey: String, mode: Mode = NormalMode)
-POST        /:taxYear/:businessId/:journey/details/completed-section                controllers.journeys.SectionCompletedStateController.onSubmit(taxYear: TaxYear, businessId: BusinessId, journey: String, mode: Mode = NormalMode)
-GET         /:taxYear/:businessId/:journey/details/change-completed-section         controllers.journeys.SectionCompletedStateController.onPageLoad(taxYear: TaxYear, businessId: BusinessId, journey: String, mode: Mode = CheckMode)
-POST        /:taxYear/:businessId/:journey/details/change-completed-section         controllers.journeys.SectionCompletedStateController.onSubmit(taxYear: TaxYear, businessId: BusinessId, journey: String, mode: Mode = CheckMode)
+GET         /:taxYear/:businessId/:journey/details/completed-section                controllers.journeys.SectionCompletedStateController.onPageLoad(taxYear: TaxYear, businessId: BusinessId, journey: Journey, mode: Mode = NormalMode)
+POST        /:taxYear/:businessId/:journey/details/completed-section                controllers.journeys.SectionCompletedStateController.onSubmit(taxYear: TaxYear, businessId: BusinessId, journey: Journey, mode: Mode = NormalMode)
+GET         /:taxYear/:businessId/:journey/details/change-completed-section         controllers.journeys.SectionCompletedStateController.onPageLoad(taxYear: TaxYear, businessId: BusinessId, journey: Journey, mode: Mode = CheckMode)
+POST        /:taxYear/:businessId/:journey/details/change-completed-section         controllers.journeys.SectionCompletedStateController.onSubmit(taxYear: TaxYear, businessId: BusinessId, journey: Journey, mode: Mode = CheckMode)
 
 ########## Trade-details Journey ##########
 

--- a/it/connectors/SelfEmploymentConnectorISpec.scala
+++ b/it/connectors/SelfEmploymentConnectorISpec.scala
@@ -19,10 +19,10 @@ package connectors
 import base.IntegrationBaseSpec
 import cats.implicits._
 import helpers.{PagerDutyAware, WiremockSpec}
-import models.common.{JourneyAnswersContext, JourneyContextWithNino, JourneyStatus}
-import models.domain.BusinessIncomeSourcesSummary
 import models.common.Journey.{ExpensesGoodsToSellOrUse, ExpensesTailoring, Income}
-import models.journeys.{Journey, JourneyNameAndStatus, TaskList}
+import models.common.{Journey, JourneyAnswersContext, JourneyContextWithNino, JourneyStatus}
+import models.domain.BusinessIncomeSourcesSummary
+import models.journeys.{JourneyNameAndStatus, TaskList}
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import play.api.http.Status._
 import play.api.libs.json.{JsObject, Json}

--- a/it/connectors/SelfEmploymentConnectorISpec.scala
+++ b/it/connectors/SelfEmploymentConnectorISpec.scala
@@ -21,7 +21,7 @@ import cats.implicits._
 import helpers.{PagerDutyAware, WiremockSpec}
 import models.common.{JourneyAnswersContext, JourneyContextWithNino, JourneyStatus}
 import models.domain.BusinessIncomeSourcesSummary
-import models.journeys.Journey.{ExpensesGoodsToSellOrUse, ExpensesTailoring, Income}
+import models.common.Journey.{ExpensesGoodsToSellOrUse, ExpensesTailoring, Income}
 import models.journeys.{Journey, JourneyNameAndStatus, TaskList}
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import play.api.http.Status._

--- a/test/base/ControllerSpec.scala
+++ b/test/base/ControllerSpec.scala
@@ -20,7 +20,7 @@ import builders.UserBuilder
 import models.common.UserType.Individual
 import models.common._
 import models.database.UserAnswers
-import models.journeys.Journey
+import models.common.Journey
 import models.{Mode, NormalMode}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchersSugar

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -24,7 +24,7 @@ import models.common._
 import models.database.UserAnswers
 import models.errors.HttpError
 import models.errors.HttpErrorBody.SingleErrorBody
-import models.journeys.Journey
+import models.common.Journey
 import models.requests.{DataRequest, OptionalDataRequest}
 import org.mockito.ArgumentMatchers.any
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}

--- a/test/base/cyaPages/CYAOnSubmitControllerBaseSpec.scala
+++ b/test/base/cyaPages/CYAOnSubmitControllerBaseSpec.scala
@@ -23,7 +23,7 @@ import models.NormalMode
 import models.common.UserType.Individual
 import models.database.UserAnswers
 import models.errors.ServiceError.ConnectorResponseError
-import models.journeys.Journey
+import models.common.Journey
 import org.mockito.IdiomaticMockito.StubbingOps
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import play.api.libs.json.JsObject
@@ -51,7 +51,7 @@ trait CYAOnSubmitControllerBaseSpec extends CYAControllerBaseSpec {
         status(result) shouldBe 303
 
         redirectLocation(result).value shouldBe journeys.routes.SectionCompletedStateController
-          .onPageLoad(taxYear, businessId, journey.toString, NormalMode)
+          .onPageLoad(taxYear, businessId, journey, NormalMode)
           .url
       }
     }

--- a/test/builders/TradesJourneyStatusesBuilder.scala
+++ b/test/builders/TradesJourneyStatusesBuilder.scala
@@ -18,7 +18,7 @@ package builders
 
 import base.SpecBase.businessId
 import models.common.{AccountingType, JourneyStatus, TradingName, TypeOfBusiness}
-import models.journeys.Journey._
+import models.common.Journey._
 import models.journeys.{JourneyNameAndStatus, TaskList}
 import models.requests.TradesJourneyStatuses
 

--- a/test/controllers/TaskListControllerSpec.scala
+++ b/test/controllers/TaskListControllerSpec.scala
@@ -27,7 +27,7 @@ import models.common.JourneyStatus
 import models.common.TaxYear.dateNow
 import models.errors.ServiceError.ConnectorResponseError
 import models.errors.{HttpError, HttpErrorBody}
-import models.journeys.Journey.TradeDetails
+import models.common.Journey.TradeDetails
 import models.journeys.{JourneyNameAndStatus, TaskList, TaskListWithRequest}
 import models.requests.TradesJourneyStatuses
 import org.scalatest.wordspec.AnyWordSpec

--- a/test/controllers/actions/SubmittedDataRetrievalActionImplSpec.scala
+++ b/test/controllers/actions/SubmittedDataRetrievalActionImplSpec.scala
@@ -25,7 +25,7 @@ import models.common.JourneyAnswersContext
 import models.database.UserAnswers
 import models.domain.ApiResultT
 import models.errors.ServiceError
-import models.journeys.Journey
+import models.common.Journey
 import models.requests.OptionalDataRequest
 import org.mockito.ArgumentMatchersSugar._
 import org.mockito.IdiomaticMockito.StubbingOps

--- a/test/controllers/actions/SubmittedDataRetrievalActionProviderImplSpec.scala
+++ b/test/controllers/actions/SubmittedDataRetrievalActionProviderImplSpec.scala
@@ -21,9 +21,9 @@ import builders.TradesJourneyStatusesBuilder._
 import cats.data.EitherT
 import cats.implicits._
 import connectors.SelfEmploymentConnector
-import models.common.{JourneyAnswersContext, Mtditid, Nino, TaxYear}
+import models.common._
 import models.errors.{HttpError, HttpErrorBody, ServiceError}
-import models.journeys.{Journey, TaskList, TaskListWithRequest}
+import models.journeys.{TaskList, TaskListWithRequest}
 import models.requests.OptionalDataRequest
 import org.mockito.ArgumentMatchersSugar._
 import org.mockito.IdiomaticMockito.StubbingOps

--- a/test/controllers/journeys/PrepopTaskListControllerSpec.scala
+++ b/test/controllers/journeys/PrepopTaskListControllerSpec.scala
@@ -25,7 +25,7 @@ import controllers.actions.AuthenticatedIdentifierAction.User
 import models.common.JourneyStatus
 import models.errors.ServiceError.ConnectorResponseError
 import models.errors.{HttpError, HttpErrorBody}
-import models.journeys.Journey.TradeDetails
+import models.common.Journey.TradeDetails
 import models.journeys.{JourneyNameAndStatus, TaskList, TaskListWithRequest}
 import models.requests.TradesJourneyStatuses
 import org.scalatest.wordspec.AnyWordSpec

--- a/test/controllers/journeys/SectionCompletedStateControllerSpec.scala
+++ b/test/controllers/journeys/SectionCompletedStateControllerSpec.scala
@@ -22,7 +22,7 @@ import models.NormalMode
 import models.common.JourneyStatus
 import models.common.UserType.Individual
 import models.errors.ServiceError
-import models.journeys.Journey
+import models.common.Journey
 import org.scalatest.prop.TableDrivenPropertyChecks
 import pages.SectionCompletedStatePage
 import play.api.data.Form
@@ -41,7 +41,7 @@ class SectionCompletedStateControllerSpec extends SpecBase with TableDrivenPrope
   val form: Form[Boolean] = formProvider(SectionCompletedStatePage, Individual)
 
   lazy val sectionCompletedStateRoute: String =
-    routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, journey.entryName, NormalMode).url
+    routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, journey, NormalMode).url
   lazy val journeyRecoveryRoute: String = controllers.standard.routes.JourneyRecoveryController.onPageLoad().url
   lazy val journeyRecoveryCall: Call    = Call("GET", journeyRecoveryRoute)
   lazy val taskListRoute: String        = routes.TaskListController.onPageLoad(taxYear).url

--- a/test/controllers/journeys/abroad/SelfEmploymentAbroadCYAControllerSpec.scala
+++ b/test/controllers/journeys/abroad/SelfEmploymentAbroadCYAControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers.journeys.abroad
 import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBaseSpec}
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
+import models.common.Journey
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.Call

--- a/test/controllers/journeys/capitalallowances/annualInvestmentAllowance/AnnualInvestmentAllowanceCYAControllerSpec.scala
+++ b/test/controllers/journeys/capitalallowances/annualInvestmentAllowance/AnnualInvestmentAllowanceCYAControllerSpec.scala
@@ -19,8 +19,8 @@ package controllers.journeys.capitalallowances.annualInvestmentAllowance
 import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBaseSpec}
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.CapitalAllowancesAnnualInvestmentAllowance
+import models.common.Journey
+import models.common.Journey.CapitalAllowancesAnnualInvestmentAllowance
 import pages.Page
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/capitalallowances/electricVehicleChargePoints/ElectricVehicleChargePointsCYAControllerSpec.scala
+++ b/test/controllers/journeys/capitalallowances/electricVehicleChargePoints/ElectricVehicleChargePointsCYAControllerSpec.scala
@@ -19,8 +19,8 @@ package controllers.journeys.capitalallowances.electricVehicleChargePoints
 import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBaseSpec}
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.CapitalAllowancesElectricVehicleChargePoints
+import models.common.Journey
+import models.common.Journey.CapitalAllowancesElectricVehicleChargePoints
 import models.journeys.capitalallowances.electricVehicleChargePoints._
 import pages.Page
 import play.api.i18n.Messages

--- a/test/controllers/journeys/capitalallowances/specialTaxSites/SpecialTaxSitesCYAControllerSpec.scala
+++ b/test/controllers/journeys/capitalallowances/specialTaxSites/SpecialTaxSitesCYAControllerSpec.scala
@@ -19,8 +19,8 @@ package controllers.journeys.capitalallowances.specialTaxSites
 import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBaseSpec}
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.CapitalAllowancesSpecialTaxSites
+import models.common.Journey
+import models.common.Journey.CapitalAllowancesSpecialTaxSites
 import models.journeys.capitalallowances.specialTaxSites.SpecialTaxSiteLocation
 import pages.Page
 import play.api.i18n.Messages

--- a/test/controllers/journeys/capitalallowances/tailoring/CapitalAllowancesCYASpec.scala
+++ b/test/controllers/journeys/capitalallowances/tailoring/CapitalAllowancesCYASpec.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import controllers.journeys.capitalallowances.tailoring.routes._
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.CapitalAllowancesTailoring
+import models.common.Journey
+import models.common.Journey.CapitalAllowancesTailoring
 import pages.Page
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/capitalallowances/zeroEmissionCars/ZeroEmissionCarsCYAControllerSpec.scala
+++ b/test/controllers/journeys/capitalallowances/zeroEmissionCars/ZeroEmissionCarsCYAControllerSpec.scala
@@ -19,8 +19,8 @@ package controllers.journeys.capitalallowances.zeroEmissionCars
 import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBaseSpec}
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.CapitalAllowancesZeroEmissionCars
+import models.common.Journey
+import models.common.Journey.CapitalAllowancesZeroEmissionCars
 import pages.Page
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/expenses/advertisingOrMarketing/AdvertisingCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/advertisingOrMarketing/AdvertisingCYAControllerSpec.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import controllers.journeys.expenses.advertisingOrMarketing
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesAdvertisingOrMarketing
+import models.common.Journey
+import models.common.Journey.ExpensesAdvertisingOrMarketing
 import pages.expenses.advertisingOrMarketing.AdvertisingOrMarketingCYAPage
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/expenses/construction/ConstructionIndustryCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/construction/ConstructionIndustryCYAControllerSpec.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import controllers.journeys.expenses.construction
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesConstruction
+import models.common.Journey
+import models.common.Journey.ExpensesConstruction
 import pages.expenses.construction.ConstructionIndustryCYAPage
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/expenses/depreciation/DepreciationCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/depreciation/DepreciationCYAControllerSpec.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import controllers.journeys.expenses.depreciation
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesDepreciation
+import models.common.Journey
+import models.common.Journey.ExpensesDepreciation
 import pages.expenses.depreciation.DepreciationCYAPage
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/expenses/entertainment/EntertainmentCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/entertainment/EntertainmentCYAControllerSpec.scala
@@ -19,8 +19,8 @@ package controllers.journeys.expenses.entertainment
 import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBaseSpec}
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesEntertainment
+import models.common.Journey
+import models.common.Journey.ExpensesEntertainment
 import pages.expenses.entertainment.EntertainmentCYAPage
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/expenses/financialCharges/FinancialChargesCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/financialCharges/FinancialChargesCYAControllerSpec.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import controllers.journeys.expenses.financialCharges.routes._
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesFinancialCharges
+import models.common.Journey
+import models.common.Journey.ExpensesFinancialCharges
 import pages.expenses.financialCharges.FinancialChargesCYAPage
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/expenses/goodsToSellOrUse/GoodsToSellOrUseCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/goodsToSellOrUse/GoodsToSellOrUseCYAControllerSpec.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import controllers.journeys.expenses.goodsToSellOrUse
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesGoodsToSellOrUse
+import models.common.Journey
+import models.common.Journey.ExpensesGoodsToSellOrUse
 import pages.expenses.goodsToSellOrUse.GoodsToSellOrUseCYAPage
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/expenses/interest/InterestCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/interest/InterestCYAControllerSpec.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import controllers.journeys.expenses.interest
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesInterest
+import models.common.Journey
+import models.common.Journey.ExpensesInterest
 import pages.expenses.interest.InterestCYAPage
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/expenses/irrecoverableDebts/IrrecoverableDebtsCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/irrecoverableDebts/IrrecoverableDebtsCYAControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers.journeys.expenses.irrecoverableDebts
 import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBaseSpec}
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
+import models.common.Journey
 import pages.expenses.irrecoverableDebts.IrrecoverableDebtsCYAPage
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/expenses/officeSupplies/OfficeSuppliesCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/officeSupplies/OfficeSuppliesCYAControllerSpec.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import controllers.journeys.expenses.officeSupplies
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesOfficeSupplies
+import models.common.Journey
+import models.common.Journey.ExpensesOfficeSupplies
 import pages.expenses.officeSupplies.OfficeSuppliesCYAPage
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/expenses/otherExpenses/OtherExpensesCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/otherExpenses/OtherExpensesCYAControllerSpec.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import controllers.journeys.expenses.otherExpenses.routes._
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesOtherExpenses
+import models.common.Journey
+import models.common.Journey.ExpensesOtherExpenses
 import pages.expenses.otherExpenses.OtherExpensesCYAPage
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/expenses/professionalFees/ProfessionalFeesCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/professionalFees/ProfessionalFeesCYAControllerSpec.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import controllers.journeys.expenses.professionalFees
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesProfessionalFees
+import models.common.Journey
+import models.common.Journey.ExpensesProfessionalFees
 import pages.expenses.professionalFees.ProfessionalFeesCYAPage
 import play.api.i18n.Messages
 import play.api.libs.json.{JsObject, Json}

--- a/test/controllers/journeys/expenses/repairsandmaintenance/RepairsAndMaintenanceCostsCYAControllerSpecII.scala
+++ b/test/controllers/journeys/expenses/repairsandmaintenance/RepairsAndMaintenanceCostsCYAControllerSpecII.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import builders.UserBuilder.{aNoddyAgentUser, aNoddyUser}
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesRepairsAndMaintenance
+import models.common.Journey
+import models.common.Journey.ExpensesRepairsAndMaintenance
 import models.requests.DataRequest
 import pages.expenses.repairsandmaintenance.RepairsAndMaintenanceCostsCYAPage
 import play.api.i18n.Messages

--- a/test/controllers/journeys/expenses/staffCosts/StaffCostsCYAControllerSpecII.scala
+++ b/test/controllers/journeys/expenses/staffCosts/StaffCostsCYAControllerSpecII.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import builders.UserBuilder.{aNoddyAgentUser, aNoddyUser}
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesStaffCosts
+import models.common.Journey
+import models.common.Journey.ExpensesStaffCosts
 import models.requests.DataRequest
 import pages.expenses.staffCosts.StaffCostsCYAPage
 import play.api.i18n.Messages

--- a/test/controllers/journeys/expenses/tailoring/ExpensesTailoringCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/tailoring/ExpensesTailoringCYAControllerSpec.scala
@@ -21,7 +21,7 @@ import builders.ExpensesTailoringJsonBuilder._
 import controllers.journeys.expenses.tailoring
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
+import models.common.Journey
 import models.journeys.expenses.ExpensesTailoring.IndividualCategories
 import pages.expenses.tailoring._
 import play.api.Application

--- a/test/controllers/journeys/expenses/workplaceRunningCosts/WorkplaceRunningCostsCYAControllerSpec.scala
+++ b/test/controllers/journeys/expenses/workplaceRunningCosts/WorkplaceRunningCostsCYAControllerSpec.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import controllers.journeys.expenses
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.ExpensesWorkplaceRunningCosts
+import models.common.Journey
+import models.common.Journey.ExpensesWorkplaceRunningCosts
 import pages.expenses.workplaceRunningCosts.WorkplaceRunningCostsCYAPage
 import play.api.Application
 import play.api.i18n.Messages

--- a/test/controllers/journeys/income/IncomeCYAControllerSpec.scala
+++ b/test/controllers/journeys/income/IncomeCYAControllerSpec.scala
@@ -20,8 +20,8 @@ import base.cyaPages.{CYAOnPageLoadControllerBaseSpec, CYAOnSubmitControllerBase
 import controllers.journeys.income
 import models.common.{BusinessId, TaxYear, UserType}
 import models.database.UserAnswers
-import models.journeys.Journey
-import models.journeys.Journey.Income
+import models.common.Journey
+import models.common.Journey.Income
 import pages.income.IncomeCYAPage
 import play.api.Application
 import play.api.i18n.Messages

--- a/test/controllers/journeys/prepop/PrepopCheckYourSelfEmploymentDetailsControllerSpec.scala
+++ b/test/controllers/journeys/prepop/PrepopCheckYourSelfEmploymentDetailsControllerSpec.scala
@@ -27,7 +27,7 @@ import models.common.BusinessId
 import models.common.UserType.Individual
 import models.domain.BusinessData
 import models.errors.ServiceError.NotFoundError
-import models.journeys.Journey.BusinessDetailsPrepop
+import models.common.Journey.BusinessDetailsPrepop
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
@@ -80,7 +80,7 @@ class PrepopCheckYourSelfEmploymentDetailsControllerSpec extends SpecBase with M
         val selfEmploymentDetails = PrepopSelfEmploymentDetailsViewModel.buildSummaryList(aBusinessData, Individual)(messages(application))
 
         running(application) {
-          val nextRoute = routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, BusinessDetailsPrepop.entryName, NormalMode).url
+          val nextRoute = routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, BusinessDetailsPrepop, NormalMode).url
 
           when(mockService.getBusiness(anyNino, anyBusinessId, anyMtditid)(any)) thenReturn EitherT.rightT(aBusinessData)
 

--- a/test/controllers/journeys/tradeDetails/SelfEmploymentSummaryControllerSpec.scala
+++ b/test/controllers/journeys/tradeDetails/SelfEmploymentSummaryControllerSpec.scala
@@ -23,6 +23,7 @@ import controllers.journeys.tradeDetails
 import controllers.journeys.tradeDetails.SelfEmploymentSummaryController.generateRowList
 import models.NormalMode
 import models.common.BusinessId
+import models.common.Journey.TradeDetails
 import models.database.UserAnswers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.FakeRequest
@@ -43,7 +44,7 @@ class SelfEmploymentSummaryControllerSpec extends SpecBase with SummaryListFluen
 
     "onPageLoad" - {
 
-      def nextRoute = journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessID, "trade-details", NormalMode).url
+      def nextRoute = journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessID, TradeDetails, NormalMode).url
 
       "must return OK and the correct view when there are no self-employments" in {
 

--- a/test/models/requests/TradesJourneyStatusesSpec.scala
+++ b/test/models/requests/TradesJourneyStatusesSpec.scala
@@ -19,8 +19,8 @@ package models.requests
 import base.SpecBase._
 import cats.implicits._
 import models.common.AccountingType.Accrual
-import models.common.JourneyStatus
-import models.journeys.{Journey, JourneyNameAndStatus}
+import models.common.{Journey, JourneyStatus}
+import models.journeys.JourneyNameAndStatus
 import org.scalatest.wordspec.AnyWordSpecLike
 
 class TradesJourneyStatusesSpec extends AnyWordSpecLike {

--- a/test/navigation/ExpensesTailoringNavigatorSpec.scala
+++ b/test/navigation/ExpensesTailoringNavigatorSpec.scala
@@ -23,7 +23,7 @@ import controllers.journeys.expenses.tailoring.simplifiedExpenses
 import controllers.journeys.routes._
 import controllers.standard.routes._
 import models._
-import models.journeys.Journey.ExpensesTailoring
+import models.common.Journey.ExpensesTailoring
 import models.journeys.expenses.ExpensesTailoring.{IndividualCategories, NoExpenses, TotalAmount}
 import models.journeys.expenses.individualCategories.FinancialExpenses.{Interest, IrrecoverableDebts, NoFinancialExpenses, OtherFinancialCharges}
 import models.journeys.expenses.individualCategories.ProfessionalServiceExpenses.{Construction, No, ProfessionalFees, Staff}
@@ -403,7 +403,7 @@ class ExpensesTailoringNavigatorSpec extends SpecBase {
       "Expenses CYA page must go to the Section Completed page with Income journey" in {
 
         navigator.nextPage(ExpensesTailoringCYAPage, NormalMode, emptyUserAnswers, taxYear, businessId) mustBe
-          SectionCompletedStateController.onPageLoad(taxYear, businessId, ExpensesTailoring.toString, NormalMode)
+          SectionCompletedStateController.onPageLoad(taxYear, businessId, ExpensesTailoring, NormalMode)
       }
 
       "must go from a page that doesn't exist in the route map to the Journey Recovery page" in {

--- a/test/services/SelfEmploymentServiceSpec.scala
+++ b/test/services/SelfEmploymentServiceSpec.scala
@@ -26,15 +26,15 @@ import controllers.actions.SubmittedDataRetrievalActionProvider
 import controllers.journeys.capitalallowances.zeroEmissionGoodsVehicle.routes
 import forms.standard.BooleanFormProvider
 import models.NormalMode
+import models.common.Journey.ExpensesGoodsToSellOrUse
 import models.common.UserType.Individual
 import models.common._
 import models.database.UserAnswers
 import models.domain.BusinessIncomeSourcesSummary
 import models.errors.ServiceError
-import models.journeys.Journey.ExpensesGoodsToSellOrUse
+import models.journeys.JourneyNameAndStatus
 import models.journeys.capitalallowances.zeroEmissionGoodsVehicle.{ZegvHowMuchDoYouWantToClaim, ZegvUseOutsideSE}
 import models.journeys.nics.TaxableProfitAndLoss
-import models.journeys.{Journey, JourneyNameAndStatus}
 import models.requests.DataRequest
 import org.mockito.IdiomaticMockito.StubbingOps
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper

--- a/test/viewmodels/NationalInsuranceContributionsViewModelSpec.scala
+++ b/test/viewmodels/NationalInsuranceContributionsViewModelSpec.scala
@@ -21,11 +21,11 @@ import builders.BusinessDataBuilder.smallProfitTaxableProfitAndLoss
 import builders.TradesJourneyStatusesBuilder.{aTadesJourneyStatusesModel, anEmptyTadesJourneyStatusesModel}
 import controllers.journeys._
 import models.NormalMode
+import models.common.Journey._
 import models.common.JourneyStatus._
 import models.common.TaxYear.dateNow
 import models.common._
-import models.journeys.Journey._
-import models.journeys.{Journey, JourneyNameAndStatus}
+import models.journeys.JourneyNameAndStatus
 import org.scalatest.prop.TableDrivenPropertyChecks
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{SummaryList, SummaryListRow}

--- a/test/viewmodels/TradeJourneyStatusesViewModelSpec.scala
+++ b/test/viewmodels/TradeJourneyStatusesViewModelSpec.scala
@@ -21,14 +21,14 @@ import cats.implicits._
 import controllers.journeys._
 import models._
 import models.common.AccountingType.Accrual
+import models.common.Journey._
 import models.common.JourneyStatus._
-import models.common.{JourneyStatus, TradingName, TypeOfBusiness}
+import models.common.{Journey, JourneyStatus, TradingName, TypeOfBusiness}
 import models.database.UserAnswers
-import models.journeys.Journey._
+import models.journeys.JourneyNameAndStatus
 import models.journeys.capitalallowances.tailoring.CapitalAllowances
 import models.journeys.expenses.individualCategories._
 import models.journeys.income.TradingAllowance
-import models.journeys.{Journey, JourneyNameAndStatus}
 import models.requests.TradesJourneyStatuses
 import org.scalatest.TryValues._
 import org.scalatest.prop.TableDrivenPropertyChecks


### PR DESCRIPTION
Relevant changes are to 'SectionCompletedStateController' and 'BusinessId' files.
The rest are import changes because of moving Journey class to models.common folder so that Journey is path bindable to be passed in to the SectionCompletedStateController routes.