### PR TITLE
[SASS-10588] Add EMA Supporting Agent FS and authorisation logic

### DIFF
--- a/app/common/EnrolmentCommon.scala
+++ b/app/common/EnrolmentCommon.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+object EnrolmentKeys {
+  val Individual      = "HMRC-MTD-IT"
+  val SupportingAgent = "HMRC-MTD-IT-SUPP"
+  val Agent           = "HMRC-AS-AGENT"
+  val nino            = "HMRC-NI"
+}
+
+object EnrolmentIdentifiers {
+  val individualId   = "MTDITID"
+  val agentReference = "AgentReferenceNumber"
+  val nino           = "NINO"
+}
+
+object DelegatedAuthRules {
+  val agentDelegatedAuthRule           = "mtd-it-auth"
+  val supportingAgentDelegatedAuthRule = "mtd-it-auth-supp"
+}

--- a/app/common/SessionValues.scala
+++ b/app/common/SessionValues.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+object SessionValues {
+  val CLIENT_MTDITID  = "ClientMTDID"
+  val CLIENT_NINO     = "ClientNino"
+  val TAX_YEAR        = "TAX_YEAR"
+  val VALID_TAX_YEARS = "validTaxYears"
+}

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -26,36 +26,37 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 @Singleton
 class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig: ServicesConfig) {
 
-  val host: String    = configuration.get[String]("host")
-  val appName: String = configuration.get[String]("appName")
+  lazy val host: String    = configuration.get[String]("host")
+  lazy val appName: String = configuration.get[String]("appName")
 
-  private val contactHost                  = configuration.get[String]("contact-frontend.host")
-  private val contactFormServiceIdentifier = "income-tax-self-employment-frontend"
+  private lazy val contactHost                  = configuration.get[String]("contact-frontend.host")
+  private lazy val contactFormServiceIdentifier = "income-tax-self-employment-frontend"
 
   def feedbackUrl(implicit request: RequestHeader): String =
     url"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier&backUrl=${host + request.uri}".toString
 
-  val loginUrl: String         = configuration.get[String]("urls.login")
-  val loginContinueUrl: String = configuration.get[String]("urls.loginContinue")
-  val signOutUrl: String       = configuration.get[String]("urls.signOut")
+  def loginUrl: String         = configuration.get[String]("urls.login")
+  def loginContinueUrl: String = configuration.get[String]("urls.loginContinue")
+  lazy val signOutUrl: String  = configuration.get[String]("urls.signOut")
 
-  private val exitSurveyBaseUrl: String = configuration.get[Service]("microservice.services.feedback-frontend").baseUrl
-  val exitSurveyUrl: String             = s"$exitSurveyBaseUrl/feedback/income-tax-self-employment-frontend"
+  private lazy val exitSurveyBaseUrl: String = configuration.get[Service]("microservice.services.feedback-frontend").baseUrl
+  lazy val exitSurveyUrl: String             = s"$exitSurveyBaseUrl/feedback/income-tax-self-employment-frontend"
 
-  val languageTranslationEnabled: Boolean =
-    configuration.get[Boolean]("features.welsh-translation")
+  // Feature switching
+  lazy val languageTranslationEnabled: Boolean = configuration.get[Boolean]("features.welsh-translation")
+  def emaSupportingAgentsEnabled: Boolean      = configuration.get[Boolean]("features.ema-supporting-agents-enabled")
 
   def languageMap: Map[String, Lang] = Map(
     "en" -> Lang("en"),
     "cy" -> Lang("cy")
   )
 
-  val selfEmploymentBEBaseUrl: String = servicesConfig.baseUrl("income-tax-self-employment")
+  lazy val selfEmploymentBEBaseUrl: String = servicesConfig.baseUrl("income-tax-self-employment")
 
-  val timeout: Int   = configuration.get[Int]("timeout-dialog.timeout")
-  val countdown: Int = configuration.get[Int]("timeout-dialog.countdown")
+  lazy val timeout: Int   = configuration.get[Int]("timeout-dialog.timeout")
+  lazy val countdown: Int = configuration.get[Int]("timeout-dialog.countdown")
 
-  val cacheTtl: Int = configuration.get[Int]("mongodb.timeToLiveInSeconds")
+  lazy val cacheTtl: Int = configuration.get[Int]("mongodb.timeToLiveInSeconds")
 
   def incomeTaxSubmissionBaseUrl: String = configuration.get[String]("microservice.services.income-tax-submission.url") +
     configuration.get[String]("microservice.services.income-tax-submission-frontend.context")

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -16,56 +16,81 @@
 
 package config
 
-import com.google.inject.{Inject, Singleton}
+import com.google.inject.{ImplementedBy, Inject, Singleton}
 import play.api.Configuration
 import play.api.i18n.Lang
 import play.api.mvc.RequestHeader
 import uk.gov.hmrc.http.StringContextOps
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
+@ImplementedBy(classOf[FrontendAppConfigImpl])
+trait FrontendAppConfig {
+  def host: String
+  def appName: String
+  def contactHost: String
+  def contactFormServiceIdentifier: String
+  def feedbackUrl(implicit request: RequestHeader): String
+  def loginUrl: String
+  def loginContinueUrl: String
+  def signOutUrl: String
+  def exitSurveyBaseUrl: String
+  def exitSurveyUrl: String
+  def languageTranslationEnabled: Boolean
+  def emaSupportingAgentsEnabled: Boolean
+  def languageMap: Map[String, Lang]
+  def selfEmploymentBEBaseUrl: String
+  def timeout: Int
+  def countdown: Int
+  def cacheTtl: Int
+  def incomeTaxSubmissionBaseUrl: String
+  def incomeTaxSubmissionIvRedirect: String
+  def incomeTaxSubmissionStartUrl(taxYear: Int): String
+  def viewAndChangeEnterUtrUrl: String
+}
+
 @Singleton
-class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig: ServicesConfig) {
+class FrontendAppConfigImpl @Inject() (configuration: Configuration, servicesConfig: ServicesConfig) extends FrontendAppConfig {
 
-  lazy val host: String    = configuration.get[String]("host")
-  lazy val appName: String = configuration.get[String]("appName")
+  override val host: String    = configuration.get[String]("host")
+  override val appName: String = configuration.get[String]("appName")
 
-  private lazy val contactHost                  = configuration.get[String]("contact-frontend.host")
-  private lazy val contactFormServiceIdentifier = "income-tax-self-employment-frontend"
+  override val contactHost                  = configuration.get[String]("contact-frontend.host")
+  override val contactFormServiceIdentifier = "income-tax-self-employment-frontend"
 
-  def feedbackUrl(implicit request: RequestHeader): String =
+  override def feedbackUrl(implicit request: RequestHeader): String =
     url"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier&backUrl=${host + request.uri}".toString
 
-  def loginUrl: String         = configuration.get[String]("urls.login")
-  def loginContinueUrl: String = configuration.get[String]("urls.loginContinue")
-  lazy val signOutUrl: String  = configuration.get[String]("urls.signOut")
+  override val loginUrl: String         = configuration.get[String]("urls.login")
+  override val loginContinueUrl: String = configuration.get[String]("urls.loginContinue")
+  override val signOutUrl: String       = configuration.get[String]("urls.signOut")
 
-  private lazy val exitSurveyBaseUrl: String = configuration.get[Service]("microservice.services.feedback-frontend").baseUrl
-  lazy val exitSurveyUrl: String             = s"$exitSurveyBaseUrl/feedback/income-tax-self-employment-frontend"
+  override val exitSurveyBaseUrl: String = configuration.get[Service]("microservice.services.feedback-frontend").baseUrl
+  override val exitSurveyUrl: String     = s"$exitSurveyBaseUrl/feedback/income-tax-self-employment-frontend"
 
   // Feature switching
-  lazy val languageTranslationEnabled: Boolean = configuration.get[Boolean]("features.welsh-translation")
-  def emaSupportingAgentsEnabled: Boolean      = configuration.get[Boolean]("features.ema-supporting-agents-enabled")
+  override val languageTranslationEnabled: Boolean = configuration.get[Boolean]("features.welsh-translation")
+  override val emaSupportingAgentsEnabled: Boolean = configuration.get[Boolean]("features.ema-supporting-agents-enabled")
 
-  def languageMap: Map[String, Lang] = Map(
+  override val languageMap: Map[String, Lang] = Map(
     "en" -> Lang("en"),
     "cy" -> Lang("cy")
   )
 
-  lazy val selfEmploymentBEBaseUrl: String = servicesConfig.baseUrl("income-tax-self-employment")
+  override val selfEmploymentBEBaseUrl: String = servicesConfig.baseUrl("income-tax-self-employment")
 
-  lazy val timeout: Int   = configuration.get[Int]("timeout-dialog.timeout")
-  lazy val countdown: Int = configuration.get[Int]("timeout-dialog.countdown")
+  override val timeout: Int   = configuration.get[Int]("timeout-dialog.timeout")
+  override val countdown: Int = configuration.get[Int]("timeout-dialog.countdown")
 
-  lazy val cacheTtl: Int = configuration.get[Int]("mongodb.timeToLiveInSeconds")
+  override val cacheTtl: Int = configuration.get[Int]("mongodb.timeToLiveInSeconds")
 
-  def incomeTaxSubmissionBaseUrl: String = configuration.get[String]("microservice.services.income-tax-submission.url") +
+  override val incomeTaxSubmissionBaseUrl: String = configuration.get[String]("microservice.services.income-tax-submission.url") +
     configuration.get[String]("microservice.services.income-tax-submission-frontend.context")
 
-  def incomeTaxSubmissionIvRedirect: String = incomeTaxSubmissionBaseUrl +
+  override val incomeTaxSubmissionIvRedirect: String = incomeTaxSubmissionBaseUrl +
     configuration.get[String]("microservice.services.income-tax-submission-frontend.iv-redirect")
 
-  def incomeTaxSubmissionStartUrl(taxYear: Int): String = s"$incomeTaxSubmissionBaseUrl/$taxYear/start"
+  override def incomeTaxSubmissionStartUrl(taxYear: Int): String = s"$incomeTaxSubmissionBaseUrl/$taxYear/start"
 
-  def viewAndChangeEnterUtrUrl: String = configuration.get[String]("microservice.services.view-and-change.url") +
+  override val viewAndChangeEnterUtrUrl: String = configuration.get[String]("microservice.services.view-and-change.url") +
     "/report-quarterly/income-and-expenses/view/agents/client-utr"
 }

--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -42,5 +42,7 @@ class Module extends AbstractModule {
     bind(classOf[SubmittedDataRetrievalActionProvider]).to(classOf[SubmittedDataRetrievalActionProviderImpl]).asEagerSingleton()
 
     bind(classOf[AuditService]).to(classOf[AuditServiceImpl]).asEagerSingleton()
+
+    bind(classOf[FrontendAppConfig]).to(classOf[FrontendAppConfigImpl]).asEagerSingleton()
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -108,6 +108,7 @@ tracking-consent-frontend {
 
 features {
   welsh-translation: true
+  ema-supporting-agents-enabled = true
 }
 
 play.i18n.langs = ["en", "cy"]

--- a/it/helpers/WiremockSpec.scala
+++ b/it/helpers/WiremockSpec.scala
@@ -21,7 +21,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
-import config.FrontendAppConfig
+import config.{FrontendAppConfig, FrontendAppConfigImpl}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
@@ -59,8 +59,8 @@ trait WiremockSpec
   protected lazy val httpClient: HttpClient = app.injector.instanceOf[HttpClient]
 
   protected val appConfig: FrontendAppConfig =
-    new FrontendAppConfig(app.injector.instanceOf[Configuration], app.injector.instanceOf[ServicesConfig]) {
-      override lazy val selfEmploymentBEBaseUrl: String = s"http://localhost:$wireMockPort"
+    new FrontendAppConfigImpl(app.injector.instanceOf[Configuration], app.injector.instanceOf[ServicesConfig]) {
+      override val selfEmploymentBEBaseUrl: String = s"http://localhost:$wireMockPort"
     }
 
   override def beforeAll(): Unit = {

--- a/it/helpers/WiremockSpec.scala
+++ b/it/helpers/WiremockSpec.scala
@@ -60,7 +60,7 @@ trait WiremockSpec
 
   protected val appConfig: FrontendAppConfig =
     new FrontendAppConfig(app.injector.instanceOf[Configuration], app.injector.instanceOf[ServicesConfig]) {
-      override val selfEmploymentBEBaseUrl: String = s"http://localhost:$wireMockPort"
+      override lazy val selfEmploymentBEBaseUrl: String = s"http://localhost:$wireMockPort"
     }
 
   override def beforeAll(): Unit = {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -34,7 +34,8 @@ object AppDependencies {
     "org.typelevel"     %% "cats-core"               % "2.12.0",
     "org.scalacheck"    %% "scalacheck"              % "1.18.0",
     "org.pegdown"        % "pegdown"                 % "1.6.0",
-    "org.mockito"       %% "mockito-scala"           % "1.17.37"
+    "org.mockito"       %% "mockito-scala"           % "1.17.37",
+    "org.scalamock"     %% "scalamock"               % "5.2.0",
   ).map(_ % "test, it")
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -57,6 +57,7 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
   val sampleUserId: UserId           = UserId("id")
   val someNino: Nino                 = Nino("someNino")
   val mtditid                        = Mtditid("someId")
+  val arn                            = "arnId"
   val businessId: BusinessId         = BusinessId("SJPR05893938418")
   val tradingName: TradingName       = TradingName("Circus Performer")
   val typeOfBusiness: TypeOfBusiness = TypeOfBusiness("Self Employed")

--- a/test/common/EnrolmentCommonSpec.scala
+++ b/test/common/EnrolmentCommonSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class EnrolmentCommonSpec extends AnyWordSpec with Matchers {
+
+  "EnrolmentKeys" should {
+    "have the correct values" in {
+      EnrolmentKeys.Individual mustBe "HMRC-MTD-IT"
+      EnrolmentKeys.SupportingAgent mustBe "HMRC-MTD-IT-SUPP"
+      EnrolmentKeys.Agent mustBe "HMRC-AS-AGENT"
+      EnrolmentKeys.nino mustBe "HMRC-NI"
+    }
+  }
+
+  "EnrolmentIdentifiers" should {
+    "have the correct values" in {
+      EnrolmentIdentifiers.individualId mustBe "MTDITID"
+      EnrolmentIdentifiers.agentReference mustBe "AgentReferenceNumber"
+      EnrolmentIdentifiers.nino mustBe "NINO"
+    }
+  }
+
+  "DelegatedAuthRules" should {
+    "have the correct values" in {
+      DelegatedAuthRules.agentDelegatedAuthRule mustBe "mtd-it-auth"
+      DelegatedAuthRules.supportingAgentDelegatedAuthRule mustBe "mtd-it-auth-supp"
+    }
+  }
+
+}

--- a/test/common/SessionValuesSpec.scala
+++ b/test/common/SessionValuesSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SessionValuesSpec extends AnyWordSpec with Matchers {
+
+  "SessionValues" should {
+    "have the correct values" in {
+      SessionValues.CLIENT_MTDITID mustBe "ClientMTDID"
+      SessionValues.CLIENT_NINO mustBe "ClientNino"
+      SessionValues.TAX_YEAR mustBe "TAX_YEAR"
+      SessionValues.VALID_TAX_YEARS mustBe "validTaxYears"
+    }
+  }
+}

--- a/test/config/MockAppConfig.scala
+++ b/test/config/MockAppConfig.scala
@@ -36,6 +36,9 @@ trait MockAppConfig extends MockFactory {
 
     def viewAndChangeEnterUtrUrl(url: String): CallHandler0[String] =
       (() => mockAppConfig.viewAndChangeEnterUtrUrl).expects().returns(url).anyNumberOfTimes()
+
+    def incomeTaxSubmissionIvRedirect(url: String): CallHandler0[String] =
+      (() => mockAppConfig.incomeTaxSubmissionIvRedirect).expects().returns(url).anyNumberOfTimes()
   }
 
 }

--- a/test/config/MockAppConfig.scala
+++ b/test/config/MockAppConfig.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import org.scalamock.handlers.CallHandler0
+import org.scalamock.scalatest.MockFactory
+
+trait MockAppConfig extends MockFactory {
+
+  lazy val mockAppConfig: FrontendAppConfig = mock[FrontendAppConfig]
+
+  object MockAppConfig {
+
+    def emaSupportingAgentsEnabled(enabled: Boolean): CallHandler0[Boolean] =
+      (() => mockAppConfig.emaSupportingAgentsEnabled).expects().returns(enabled)
+
+    def loginUrl(url: String): CallHandler0[String] =
+      (() => mockAppConfig.loginUrl).expects().returns(url).anyNumberOfTimes()
+
+    def loginContinueUrl(url: String): CallHandler0[String] =
+      (() => mockAppConfig.loginContinueUrl).expects().returns(url).anyNumberOfTimes()
+
+    def viewAndChangeEnterUtrUrl(url: String): CallHandler0[String] =
+      (() => mockAppConfig.viewAndChangeEnterUtrUrl).expects().returns(url).anyNumberOfTimes()
+  }
+
+}

--- a/test/connectors/MockAuthConnector.scala
+++ b/test/connectors/MockAuthConnector.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import org.scalamock.handlers.CallHandler4
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait MockAuthConnector extends MockFactory {
+
+  lazy val mockAuthConnector: AuthConnector = mock[AuthConnector]
+
+  object MockAuthConnector {
+
+    def authorise[T](predicate: Predicate)(response: Future[T]): CallHandler4[Predicate, Retrieval[T], HeaderCarrier, ExecutionContext, Future[T]] =
+      (mockAuthConnector
+        .authorise[T](_: Predicate, _: Retrieval[T])(_: HeaderCarrier, _: ExecutionContext))
+        .expects(predicate, *, *, *)
+        .returns(response)
+  }
+
+}

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -17,172 +17,330 @@
 package controllers.actions
 
 import base.SpecBase
-import com.google.inject.Inject
-import config.FrontendAppConfig
+import common.{DelegatedAuthRules, EnrolmentIdentifiers, EnrolmentKeys, SessionValues}
+import config.MockAppConfig
+import connectors.MockAuthConnector
 import controllers.standard.routes
-import play.api.mvc.{BodyParsers, Results}
+import play.api.mvc.{Action, AnyContent, BodyParsers, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.auth.core.authorise.Predicate
-import uk.gov.hmrc.auth.core.retrieve.Retrieval
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
+import uk.gov.hmrc.auth.core.retrieve.~
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
-class AuthActionSpec extends SpecBase {
+class AuthActionSpec extends SpecBase with MockAppConfig with MockAuthConnector {
 
-  class Harness(authAction: IdentifierAction) {
-    def onPageLoad() = authAction(_ => Results.Ok)
+  trait Fixture {
+
+    MockAppConfig.loginUrl("/sign-in")
+    MockAppConfig.loginContinueUrl("/continue-url")
+    MockAppConfig.viewAndChangeEnterUtrUrl("/enter-utr")
+
+    lazy val application = applicationBuilder(userAnswers = None).build()
+    lazy val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
+
+    lazy val authAction = new AuthenticatedIdentifierAction(mockAuthConnector, mockAppConfig, bodyParsers)
+
+    class Harness(authAction: IdentifierAction) {
+      def onPageLoad(): Action[AnyContent] = authAction(_ => Results.Ok)
+    }
+
+    lazy val controller = new Harness(authAction)
   }
 
   "Auth Action" - {
 
-    "when the user hasn't logged in" - {
+    "when user is an Individual and authorised with a satisfactory confidence level" - {
 
-      "must redirect the user to log in " in {
+      "must return OK" in new Fixture {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        val enrolments = Enrolments(
+          Set(
+            Enrolment(EnrolmentKeys.Individual, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, mtditid.value)), "Activated"),
+            Enrolment(EnrolmentKeys.nino, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.nino, someNino.value)), "Activated")
+          ))
 
-        running(application) {
-          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
-          val appConfig   = application.injector.instanceOf[FrontendAppConfig]
+        MockAuthConnector
+          .authorise(EmptyPredicate)(
+            Future.successful(new ~(Some("internalId"), Some(AffinityGroup.Individual)))
+          )
+          .once()
 
-          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new MissingBearerToken), appConfig, bodyParsers)
-          val controller = new Harness(authAction)
-          val result     = controller.onPageLoad()(FakeRequest())
+        MockAuthConnector
+          .authorise(EmptyPredicate)(
+            Future.successful(new ~(enrolments, ConfidenceLevel.L250))
+          )
+          .once()
+
+        val result = controller.onPageLoad()(FakeRequest())
+
+        status(result) mustBe OK
+      }
+    }
+
+    "when user is an Agent" - {
+
+      "when a clientID and NINO are in session" - {
+
+        val fakeRequestWithMtditidAndNINO = FakeRequest().withSession(
+          SessionValues.CLIENT_MTDITID -> mtditid.value,
+          SessionValues.CLIENT_NINO    -> someNino.value
+        )
+
+        "Authorised as a Primary Agent" - {
+
+          "must return OK" in new Fixture {
+
+            val enrolments = Enrolments(
+              Set(
+                Enrolment(
+                  key = EnrolmentKeys.Individual,
+                  identifiers = Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, mtditid.value)),
+                  state = "Activated",
+                  delegatedAuthRule = Some(DelegatedAuthRules.agentDelegatedAuthRule)
+                ),
+                Enrolment(EnrolmentKeys.nino, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.nino, someNino.value)), "Activated"),
+                Enrolment(EnrolmentKeys.Agent, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.agentReference, arn)), "Activated")
+              ))
+
+            MockAuthConnector
+              .authorise(EmptyPredicate)(Future.successful(new ~(Some("internalId"), Some(AffinityGroup.Agent))))
+
+            MockAuthConnector
+              .authorise(authAction.agentAuthPredicate(mtditid.value))(Future.successful(enrolments))
+
+            val result = controller.onPageLoad()(fakeRequestWithMtditidAndNINO)
+
+            status(result) mustBe OK
+          }
+        }
+
+        "Not Authorised as a Primary Agent" - {
+
+          "when EMA Supporting Agent feature is enabled" - {
+
+            "must return OK" in new Fixture {
+
+              MockAppConfig.emaSupportingAgentsEnabled(true)
+
+              val enrolments = Enrolments(Set(
+                Enrolment(
+                  key = EnrolmentKeys.SupportingAgent,
+                  identifiers = Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, mtditid.value)),
+                  state = "Activated",
+                  delegatedAuthRule = Some(DelegatedAuthRules.supportingAgentDelegatedAuthRule)
+                ),
+                Enrolment(EnrolmentKeys.nino, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.nino, someNino.value)), "Activated"),
+                Enrolment(EnrolmentKeys.Agent, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.agentReference, arn)), "Activated")
+              ))
+
+              MockAuthConnector
+                .authorise(EmptyPredicate)(
+                  Future.successful(new ~(Some("internalId"), Some(AffinityGroup.Agent)))
+                )
+
+              MockAuthConnector
+                .authorise(authAction.agentAuthPredicate(mtditid.value))(Future.failed(InsufficientEnrolments()))
+
+              MockAuthConnector
+                .authorise(authAction.secondaryAgentPredicate(mtditid.value))(Future.successful(enrolments))
+
+              val result = controller.onPageLoad()(fakeRequestWithMtditidAndNINO)
+
+              status(result) mustBe OK
+            }
+          }
+
+          "when EMA Supporting Agent feature is disabled" - {
+
+            "must return SEE_OTHER (303) and redirect to Agent Error page" in new Fixture {
+
+              MockAppConfig.emaSupportingAgentsEnabled(false)
+
+              val enrolments = Enrolments(Set(
+                Enrolment(
+                  key = EnrolmentKeys.SupportingAgent,
+                  identifiers = Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, mtditid.value)),
+                  state = "Activated",
+                  delegatedAuthRule = Some(DelegatedAuthRules.supportingAgentDelegatedAuthRule)
+                ),
+                Enrolment(EnrolmentKeys.nino, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.nino, someNino.value)), "Activated"),
+                Enrolment(EnrolmentKeys.Agent, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.agentReference, arn)), "Activated")
+              ))
+
+              MockAuthConnector
+                .authorise(EmptyPredicate)(
+                  Future.successful(new ~(Some("internalId"), Some(AffinityGroup.Agent)))
+                )
+
+              MockAuthConnector
+                .authorise(authAction.agentAuthPredicate(mtditid.value))(Future.failed(InsufficientEnrolments()))
+
+              val result = controller.onPageLoad()(fakeRequestWithMtditidAndNINO)
+
+              status(result) mustBe SEE_OTHER
+              redirectLocation(result) mustBe Some(controllers.authorisationErrors.routes.AgentAuthErrorController.onPageLoad.url)
+            }
+          }
+        }
+      }
+
+      "when a clientID is missing from session" - {
+
+        val fakeRequestWithNINO = FakeRequest().withSession(
+          SessionValues.CLIENT_NINO -> someNino.value
+        )
+
+        "must return SEE_OTHER (303) and redirect to Agent Error page" in new Fixture {
+
+          val enrolments = Enrolments(
+            Set(
+              Enrolment(
+                key = EnrolmentKeys.SupportingAgent,
+                identifiers = Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, mtditid.value)),
+                state = "Activated",
+                delegatedAuthRule = Some(DelegatedAuthRules.supportingAgentDelegatedAuthRule)
+              ),
+              Enrolment(EnrolmentKeys.nino, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.nino, someNino.value)), "Activated"),
+              Enrolment(EnrolmentKeys.Agent, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.agentReference, arn)), "Activated")
+            ))
+
+          MockAuthConnector
+            .authorise(EmptyPredicate)(
+              Future.successful(new ~(Some("internalId"), Some(AffinityGroup.Agent)))
+            )
+
+          val result = controller.onPageLoad()(fakeRequestWithNINO)
 
           status(result) mustBe SEE_OTHER
-          redirectLocation(result).value must startWith(appConfig.loginUrl)
+          redirectLocation(result) mustBe Some(mockAppConfig.viewAndChangeEnterUtrUrl)
         }
+      }
+
+      "when a NINO is missing from session" - {
+
+        val fakeRequestWithMtditid = FakeRequest().withSession(
+          SessionValues.CLIENT_MTDITID -> mtditid.value
+        )
+
+        "must return SEE_OTHER (303) and redirect to Agent Error page" in new Fixture {
+
+          val enrolments = Enrolments(
+            Set(
+              Enrolment(
+                key = EnrolmentKeys.SupportingAgent,
+                identifiers = Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, mtditid.value)),
+                state = "Activated",
+                delegatedAuthRule = Some(DelegatedAuthRules.supportingAgentDelegatedAuthRule)
+              ),
+              Enrolment(EnrolmentKeys.nino, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.nino, someNino.value)), "Activated"),
+              Enrolment(EnrolmentKeys.Agent, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.agentReference, arn)), "Activated")
+            ))
+
+          MockAuthConnector
+            .authorise(EmptyPredicate)(
+              Future.successful(new ~(Some("internalId"), Some(AffinityGroup.Agent)))
+            )
+
+          val result = controller.onPageLoad()(fakeRequestWithMtditid)
+
+          status(result) mustBe SEE_OTHER
+          redirectLocation(result) mustBe Some(mockAppConfig.viewAndChangeEnterUtrUrl)
+        }
+      }
+    }
+
+    "when the user hasn't logged in" - {
+
+      "must redirect the user to log in " in new Fixture {
+
+        MockAuthConnector.authorise(EmptyPredicate)(Future.failed(MissingBearerToken()))
+
+        val result = controller.onPageLoad()(FakeRequest())
+
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).value must startWith(mockAppConfig.loginUrl)
       }
     }
 
     "the user's session has expired" - {
 
-      "must redirect the user to log in " in {
+      "must redirect the user to log in " in new Fixture {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        MockAuthConnector.authorise(EmptyPredicate)(Future.failed(BearerTokenExpired()))
 
-        running(application) {
-          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
-          val appConfig   = application.injector.instanceOf[FrontendAppConfig]
+        val result = controller.onPageLoad()(FakeRequest())
 
-          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new BearerTokenExpired), appConfig, bodyParsers)
-          val controller = new Harness(authAction)
-          val result     = controller.onPageLoad()(FakeRequest())
-
-          status(result) mustBe SEE_OTHER
-          redirectLocation(result).value must startWith(appConfig.loginUrl)
-        }
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).value must startWith(mockAppConfig.loginUrl)
       }
     }
 
     "the user doesn't have sufficient enrolments" - {
 
-      "must redirect the user to the unauthorised page" in {
+      "must redirect the user to the unauthorised page" in new Fixture {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        MockAuthConnector.authorise(EmptyPredicate)(Future.failed(InsufficientEnrolments()))
 
-        running(application) {
-          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
-          val appConfig   = application.injector.instanceOf[FrontendAppConfig]
+        val result = controller.onPageLoad()(FakeRequest())
 
-          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new InsufficientEnrolments), appConfig, bodyParsers)
-          val controller = new Harness(authAction)
-          val result     = controller.onPageLoad()(FakeRequest())
-
-          status(result) mustBe SEE_OTHER
-          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad.url
-        }
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad.url
       }
     }
 
     "the user doesn't have sufficient confidence level" - {
 
-      "must redirect the user to the unauthorised page" in {
+      "must redirect the user to the unauthorised page" in new Fixture {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        MockAuthConnector.authorise(EmptyPredicate)(Future.failed(InsufficientConfidenceLevel()))
 
-        running(application) {
-          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
-          val appConfig   = application.injector.instanceOf[FrontendAppConfig]
+        val result = controller.onPageLoad()(FakeRequest())
 
-          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new InsufficientConfidenceLevel), appConfig, bodyParsers)
-          val controller = new Harness(authAction)
-          val result     = controller.onPageLoad()(FakeRequest())
-
-          status(result) mustBe SEE_OTHER
-          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad.url
-        }
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad.url
       }
     }
 
     "the user used an unaccepted auth provider" - {
 
-      "must redirect the user to the unauthorised page" in {
+      "must redirect the user to the unauthorised page" in new Fixture {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        MockAuthConnector.authorise(EmptyPredicate)(Future.failed(UnsupportedAuthProvider()))
 
-        running(application) {
-          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
-          val appConfig   = application.injector.instanceOf[FrontendAppConfig]
+        val result = controller.onPageLoad()(FakeRequest())
 
-          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedAuthProvider), appConfig, bodyParsers)
-          val controller = new Harness(authAction)
-          val result     = controller.onPageLoad()(FakeRequest())
-
-          status(result) mustBe SEE_OTHER
-          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad.url
-        }
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad.url
       }
     }
 
     "the user has an unsupported affinity group" - {
 
-      "must redirect the user to the unauthorised page" in {
+      "must redirect the user to the unauthorised page" in new Fixture {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        MockAuthConnector.authorise(EmptyPredicate)(Future.failed(UnsupportedAffinityGroup()))
 
-        running(application) {
-          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
-          val appConfig   = application.injector.instanceOf[FrontendAppConfig]
+        val result = controller.onPageLoad()(FakeRequest())
 
-          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedAffinityGroup), appConfig, bodyParsers)
-          val controller = new Harness(authAction)
-          val result     = controller.onPageLoad()(FakeRequest())
-
-          status(result) mustBe SEE_OTHER
-          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad.url)
-        }
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad.url)
       }
     }
 
     "the user has an unsupported credential role" - {
 
-      "must redirect the user to the unauthorised page" in {
+      "must redirect the user to the unauthorised page" in new Fixture {
 
-        val application = applicationBuilder(userAnswers = None).build()
+        MockAuthConnector.authorise(EmptyPredicate)(Future.failed(UnsupportedCredentialRole()))
 
-        running(application) {
-          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
-          val appConfig   = application.injector.instanceOf[FrontendAppConfig]
+        val result = controller.onPageLoad()(FakeRequest())
 
-          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedCredentialRole), appConfig, bodyParsers)
-          val controller = new Harness(authAction)
-          val result     = controller.onPageLoad()(FakeRequest())
-
-          status(result) mustBe SEE_OTHER
-          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad.url)
-        }
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad.url)
       }
     }
   }
-}
-
-class FakeFailingAuthConnector @Inject() (exceptionToReturn: Throwable) extends AuthConnector {
-  val serviceUrl: String = ""
-
-  override def authorise[A](predicate: Predicate, retrieval: Retrieval[A])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[A] =
-    Future.failed(exceptionToReturn)
 }

--- a/test/controllers/actions/AuthenticatedIdentifierActionSpec.scala
+++ b/test/controllers/actions/AuthenticatedIdentifierActionSpec.scala
@@ -19,7 +19,8 @@ package controllers.actions
 import base.SpecBase
 import base.SpecBase.taxYear
 import config.FrontendAppConfig
-import controllers.actions.AuthenticatedIdentifierAction.{EnrolmentIdentifiers, EnrolmentKeys, SessionValues, User}
+import common._
+import controllers.actions.AuthenticatedIdentifierAction.User
 import models.common.TaxYear
 import models.requests.IdentifierRequest
 import org.mockito.ArgumentMatchers

--- a/test/controllers/actions/IndividualAuthenticatedSpec.scala
+++ b/test/controllers/actions/IndividualAuthenticatedSpec.scala
@@ -18,7 +18,7 @@ package controllers.actions
 
 import base.SpecBase
 import config.FrontendAppConfig
-import controllers.actions.AuthenticatedIdentifierAction.{EnrolmentIdentifiers, EnrolmentKeys}
+import common._
 import models.requests.IdentifierRequest
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any


### PR DESCRIPTION
Notes:
- Adds Feature Switch for the Supporting/Secondary Agent authorisation
- Logic added to Agent authentication when Feature Switch is enabled
- Updates the `User` class to have a flag for `isSupportingAgent` which may be necessary to limit functionality as part of future stories
- Refactors the AuthSpec so that Scalamock is utilised to simulate different responses from AuthConnector to make tests more verbose, better coverage and specific scenarios tested

App-Config-* PR(s) to be reviewed at the same time:
- https://github.com/hmrc/app-config-base/pull/11376