### PR TITLE
Removing change links and remove self employment link

### DIFF
--- a/app/viewmodels/checkAnswers/tradeDetails/SelfEmploymentDetailsViewModel.scala
+++ b/app/viewmodels/checkAnswers/tradeDetails/SelfEmploymentDetailsViewModel.scala
@@ -56,8 +56,7 @@ object SelfEmploymentDetailsViewModel {
       value = Value(
         content = rowContent,
         classes = "govuk-!-width-one-third"
-      ),
-      actions = Seq(ActionItemViewModel(messages("site.change"), "#"))
+      )
     )
   }
 

--- a/app/views/journeys/tradeDetails/CheckYourSelfEmploymentDetailsView.scala.html
+++ b/app/views/journeys/tradeDetails/CheckYourSelfEmploymentDetailsView.scala.html
@@ -37,13 +37,9 @@
         @govukButton(Button(
             attributes = Map("id" -> "continue"),
             preventDoubleClick = Some(true),
-            content = Text(messages("site.saveAndContinue")),
+            content = Text(messages("site.continue")),
             classes = "govuk-button"
         ).asLink(nextRoute))
-
-        <a href="#" class ="govuk-link">
-            @messages("checkYourSelfEmploymentDetails.removeSelfEmployment")
-        </a>
     </div>
 
 }


### PR DESCRIPTION
We cannot access this data for editing, therefore we cannot change or remove. We can only display it, meaning these links are redundant and not required.

## Before
<img width="1016" alt="Screenshot 2025-01-27 at 10 51 07" src="https://github.com/user-attachments/assets/5ca26e63-8561-4795-96d5-e4f5ff57e507" />


## After
<img width="1001" alt="Screenshot 2025-01-27 at 10 50 27" src="https://github.com/user-attachments/assets/bde49fe4-76bf-400c-b997-6def29fb283d" />
