### PR TITLE
Accessibility - assign paragraph class correctly

### DIFF
--- a/app/views/journeys/adjustments/profitOrLoss/ClaimLossReliefView.scala.html
+++ b/app/views/journeys/adjustments/profitOrLoss/ClaimLossReliefView.scala.html
@@ -37,9 +37,9 @@
 
         @heading("claimLossRelief.title")
 
-        <div class="govuk-body">
-            <p>@messages(s"claimLossRelief.p1.$userType")</p>
-            <p>@messages(s"claimLossRelief.p2.$userType")</p>
+        <div class="govuk-form-group">
+            <p class="govuk-body">@messages(s"claimLossRelief.p1.$userType")</p>
+            <p class="govuk-body">@messages(s"claimLossRelief.p2.$userType")</p>
 
             <ul class="govuk-list govuk-list--bullet">
                 <li>@messages(s"claimLossRelief.l1.$userType")</li>

--- a/app/views/journeys/adjustments/profitOrLoss/GoodsAndServicesForYourOwnUseView.scala.html
+++ b/app/views/journeys/adjustments/profitOrLoss/GoodsAndServicesForYourOwnUseView.scala.html
@@ -42,12 +42,12 @@
 
     @heading(s"goodsAndServicesForYourOwnUse.title.$userType")
 
-    <div class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6">
-        <p>@messages(s"goodsAndServicesForYourOwnUse.p1.$userType.$accountingType")<p>
-    <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
-        <li>@messages(s"goodsAndServicesForYourOwnUse.l1.$userType")</li>
-        <li>@messages(s"goodsAndServicesForYourOwnUse.l2")</li>
-    </ul>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"goodsAndServicesForYourOwnUse.p1.$userType.$accountingType")</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>@messages(s"goodsAndServicesForYourOwnUse.l1.$userType")</li>
+            <li>@messages(s"goodsAndServicesForYourOwnUse.l2")</li>
+        </ul>
     </div>
 
     @formHelper(action = routes.GoodsAndServicesForYourOwnUseController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/adjustments/profitOrLoss/WhichYearIsLossReportedView.scala.html
+++ b/app/views/journeys/adjustments/profitOrLoss/WhichYearIsLossReportedView.scala.html
@@ -38,9 +38,9 @@
 
         @heading(s"whichYearIsLossReported.title.$userType")
 
-        <div class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6">
-            <p>@messages(s"whichYearIsLossReported.p1.loss.$userType")<p>
-            <p>@messages(s"whichYearIsLossReported.p2.loss.$userType")<p>
+        <div class="govuk-form-group">
+            <p class="govuk-body">@messages(s"whichYearIsLossReported.p1.loss.$userType")</p>
+            <p class="govuk-body">@messages(s"whichYearIsLossReported.p2.loss.$userType")</p>
         </div>
 
         @govukRadios(

--- a/app/views/journeys/capitalallowances/annualInvestmentAllowance/AnnualInvestmentAllowanceView.scala.html
+++ b/app/views/journeys/capitalallowances/annualInvestmentAllowance/AnnualInvestmentAllowanceView.scala.html
@@ -34,23 +34,23 @@
 
     <h1 class="govuk-heading-l">@messages("selectCapitalAllowances.annualInvestment.cya")</h1>
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>@messages(s"annualInvestmentAllowance.p1.$userType")</p>
-        <p>@messages(s"annualInvestmentAllowance.p2.$userType")</p>
-        <p>@messages(s"annualInvestmentAllowance.p3.$userType")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"annualInvestmentAllowance.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"annualInvestmentAllowance.p2.$userType")</p>
+        <p class="govuk-body">@messages(s"annualInvestmentAllowance.p3.$userType")</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"annualInvestmentAllowance.l1.$userType")</li>
             <li>@messages(s"annualInvestmentAllowance.l2.$userType")</li>
         </ul>
 
-        <h1 class="govuk-heading-m">@messages("annualInvestmentAllowance.aiaLimit")</h1>
+        <h2 class="govuk-heading-m">@messages("annualInvestmentAllowance.aiaLimit")</h2>
 
-        <p>
+        <p class="govuk-body">
             @messages(s"annualInvestmentAllowance.p4.$userType")
             <a class="govuk-link" target="_blank" href=@messages("annualInvestmentAllowance.link1.href") >@messages(s"annualInvestmentAllowance.link1.$userType")</a>
             @messages("common.opensInNewTab").
         </p>
-        <p>
+        <p class="govuk-body">
             <a class="govuk-link" target="_blank" href=@messages("annualInvestmentAllowance.link2.href") >@messages("annualInvestmentAllowance.link2")</a>
             @messages("common.opensInNewTab")
         </p>

--- a/app/views/journeys/capitalallowances/balancingAllowance/BalancingAllowanceView.scala.html
+++ b/app/views/journeys/capitalallowances/balancingAllowance/BalancingAllowanceView.scala.html
@@ -35,18 +35,18 @@
 
     @heading("balancingAllowance.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>@messages(s"balancingAllowance.p1.$userType")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"balancingAllowance.p1.$userType")</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"balancingAllowance.p2.$userType")</li>
             <li>@messages(s"balancingAllowance.p3.$userType")</li>
         </ul>
-        <p>@messages(s"balancingAllowance.p4.$userType")</p>
+        <p class="govuk-body">@messages(s"balancingAllowance.p4.$userType")</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"balancingAllowance.p5.$userType")</li>
             <li>@messages(s"balancingAllowance.p6.$userType")</li>
         </ul>
-        <p>@messages(s"balancingAllowance.p7.read")
+        <p class="govuk-body">@messages(s"balancingAllowance.p7.read")
             <a class="govuk-link" target="_blank" href=@messages("balancingAllowance.p7.href") >@messages("balancingAllowance.p7.link")</a>
             @messages("common.opensInNewTab")
         </p>

--- a/app/views/journeys/capitalallowances/balancingCharge/BalancingChargeView.scala.html
+++ b/app/views/journeys/capitalallowances/balancingCharge/BalancingChargeView.scala.html
@@ -35,17 +35,17 @@
 
     @heading("balancingCharge.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
             @messages(s"balancingCharge.p1.$userType")
             @messages("balancingCharge.p2")
             @messages(s"balancingCharge.p3.$userType")
         </p>
-        <p>
+        <p class="govuk-body">
             @messages(s"balancingCharge.p4.$userType")
             @messages(s"balancingCharge.p5.$userType")
         </p>
-        <p>@messages("balancingAllowance.p7.read")
+        <p class="govuk-body">@messages("balancingAllowance.p7.read")
             <a class="govuk-link" target="_blank" href=@messages("balancingAllowance.p7.href") >@messages("balancingCharge.p6.link")</a>
             @messages("common.opensInNewTab")
         </p>

--- a/app/views/journeys/capitalallowances/specialTaxSites/ContinueClaimingAllowanceForExistingSiteView.scala.html
+++ b/app/views/journeys/capitalallowances/specialTaxSites/ContinueClaimingAllowanceForExistingSiteView.scala.html
@@ -35,14 +35,14 @@
 
     @heading(s"structuresBuildingsPreviousClaimUse.title.$userType")
 
-    <div class="govuk-body">
-        <p>@messages(s"structuresBuildingsPreviousClaimUse.p1.$userType")</p>
-        <ul class="govuk-body govuk-list--bullet">
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"structuresBuildingsPreviousClaimUse.p1.$userType")</p>
+        <ul class="govuk-list govuk-list--bullet">
             <li>@{messages("structuresBuildingsPreviousClaimUse.l1")}</li>
             <li>@{messages("structuresBuildingsPreviousClaimUse.l2")}</li>
         </ul>
-        <p>@messages(s"continueClaimingAllowanceForExistingSite.p2.$userType")</p>
-        <p>@messages(s"continueClaimingAllowanceForExistingSite.p3.$userType")</p>
+        <p class="govuk-body">@messages(s"continueClaimingAllowanceForExistingSite.p2.$userType")</p>
+        <p class="govuk-body">@messages(s"continueClaimingAllowanceForExistingSite.p3.$userType")</p>
     </div>
 
     @formHelper(action = routes.ContinueClaimingAllowanceForExistingSiteController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/capitalallowances/specialTaxSites/ContractForBuildingConstructionView.scala.html
+++ b/app/views/journeys/capitalallowances/specialTaxSites/ContractForBuildingConstructionView.scala.html
@@ -34,9 +34,9 @@
 
     @heading("contractForBuildingConstruction.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>@messages(s"contractForBuildingConstruction.p1.$userType")</p>
-        <ul class="govuk-body govuk-list--bullet">
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"contractForBuildingConstruction.p1.$userType")</p>
+        <ul class="govuk-list govuk-list--bullet">
             <li>@{messages("contractForBuildingConstruction.l1")}</li>
             <li>@{messages("contractForBuildingConstruction.l2")}</li>
         </ul>

--- a/app/views/journeys/capitalallowances/specialTaxSites/ExistingSiteClaimingAmountView.scala.html
+++ b/app/views/journeys/capitalallowances/specialTaxSites/ExistingSiteClaimingAmountView.scala.html
@@ -37,14 +37,14 @@
 
     @heading(s"existingSiteClaimingAmount.title")
 
-    <div class="govuk-body">
-      <p>@messages(s"existingSiteClaimingAmount.details.p1.$userType")</p>
-      <p>@messages("existingSiteClaimingAmount.details.p2")</p>
+    <div class="govuk-form-group">
+      <p class="govuk-body">@messages(s"existingSiteClaimingAmount.details.p1.$userType")</p>
+      <p class="govuk-body">@messages("existingSiteClaimingAmount.details.p2")</p>
       <ul class="govuk-list govuk-list--bullet">
           <li>@messages("existingSiteClaimingAmount.details.l1")</li>
           <li>@messages("existingSiteClaimingAmount.details.l2")</li>
       </ul>
-      <p>@messages("existingSiteClaimingAmount.details.p3")</p>
+      <p class="govuk-body">@messages("existingSiteClaimingAmount.details.p3")</p>
     </div>
 
     @formHelper(action = routes.ExistingSiteClaimingAmountController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/capitalallowances/specialTaxSites/NewSiteClaimingAmountView.scala.html
+++ b/app/views/journeys/capitalallowances/specialTaxSites/NewSiteClaimingAmountView.scala.html
@@ -38,10 +38,10 @@
 
     @heading("capitalAllowance.claimingTheAllowance")
 
-    <div class="govuk-body">
-        <p>@messages(s"newSiteClaimingAmount.p1.$userType")</p>
-        <p>@messages(s"newSiteClaimingAmount.p2.$userType")</p>
-        <ul>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"newSiteClaimingAmount.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"newSiteClaimingAmount.p2.$userType")</p>
+        <ul class="govuk-list">
             <li>@messages(s"newSiteClaimingAmount.l1.$userType")</li>
             <li>@messages(s"newSiteClaimingAmount.l2.$userType")</li>
             <li>@messages("newSiteClaimingAmount.l3")</li>
@@ -49,15 +49,15 @@
     </div>
 
     @foldableDetails(messages(s"newSiteClaimingAmount.details.heading.$userType")) {
-        <p>@messages(s"newSiteClaimingAmount.details.p1.$userType")</p>
-        <p>@messages(s"newSiteClaimingAmount.details.p2.$userType")</p>
-        <p>@messages("newSiteClaimingAmount.details.p3")</p>
+        <p class="govuk-body">@messages(s"newSiteClaimingAmount.details.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"newSiteClaimingAmount.details.p2.$userType")</p>
+        <p class="govuk-body">@messages("newSiteClaimingAmount.details.p3")</p>
         <ul class="govuk-list govuk-list--bullet"><li>@messages("newSiteClaimingAmount.details.l1")</li></ul>
-        <p>@messages("newSiteClaimingAmount.details.p4")</p>
+        <p class="govuk-body">@messages("newSiteClaimingAmount.details.p4")</p>
         <ul class="govuk-list govuk-list--bullet"><li>@messages("newSiteClaimingAmount.details.l2")</li></ul>
-        <p>@messages("newSiteClaimingAmount.details.p5")</p>
+        <p class="govuk-body">@messages("newSiteClaimingAmount.details.p5")</p>
         <ul class="govuk-list govuk-list--bullet"><li>@messages("newSiteClaimingAmount.details.l3")</li></ul>
-        <p>@messages("newSiteClaimingAmount.details.p6")</p>
+        <p class="govuk-body">@messages("newSiteClaimingAmount.details.p6")</p>
     }
 
     @formHelper(action = routes.NewSiteClaimingAmountController.onSubmit(taxYear, businessId, index, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/capitalallowances/specialTaxSites/QualifyingUseStartDateView.scala.html
+++ b/app/views/journeys/capitalallowances/specialTaxSites/QualifyingUseStartDateView.scala.html
@@ -34,8 +34,8 @@
 
     @heading("structuresBuildingsQualifyingUseDate.title")
 
-        <div class="govuk-body">
-            <p>@messages("structuresBuildingsQualifyingUseDate.p1")</p>
+        <div class="govuk-form-group">
+            <p class="govuk-body">@messages("structuresBuildingsQualifyingUseDate.p1")</p>
         </div>
 
     @formHelper(action = routes.QualifyingUseStartDateController.onSubmit(taxYear, businessId, index, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/capitalallowances/specialTaxSites/SpecialTaxSitesView.scala.html
+++ b/app/views/journeys/capitalallowances/specialTaxSites/SpecialTaxSitesView.scala.html
@@ -35,14 +35,14 @@
 
     @heading("specialTaxSites.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>@messages("specialTaxSites.p1")</p>
-        <p>@messages(s"specialTaxSites.p2.$userType")</p>
-        <p>@messages("specialTaxSites.p3")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages("specialTaxSites.p1")</p>
+        <p class="govuk-body">@messages(s"specialTaxSites.p2.$userType")</p>
+        <p class="govuk-body">@messages("specialTaxSites.p3")</p>
 
         @foldableDetails(messages("specialTaxSites.details.heading")) {
-            <p>@messages(s"specialTaxSites.details.p1.$userType")</p>
-            <ul class="govuk-body govuk-list--bullet">
+            <p class="govuk-body">@messages(s"specialTaxSites.details.p1.$userType")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("specialTaxSites.details.l1")</li>
                 <li>@messages("specialTaxSites.details.l2")</li>
                 <li>@messages("specialTaxSites.details.l3")</li>

--- a/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsAllowanceView.scala.html
+++ b/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsAllowanceView.scala.html
@@ -35,16 +35,16 @@
 
         @heading("selectCapitalAllowances.structuresAndBuildings")
 
-        <div class="govuk-body govuk-!-margin-top-6">
-            <p>@messages(s"structuresBuildingsAllowance.p1.$userType")</p>
+        <div class="govuk-form-group">
+            <p class="govuk-body">@messages(s"structuresBuildingsAllowance.p1.$userType")</p>
 
-            <ul class="govuk-list--bullet">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages(s"structuresBuildingsAllowance.p2.$userType")</li>
                 <li>@messages(s"structuresBuildingsAllowance.p3")</li>
                 <li>@messages(s"structuresBuildingsAllowance.p4")</li>
             </ul>
 
-            <p>@messages(s"structuresBuildingsAllowance.p5.$userType")</p>
+            <p class="govuk-body">@messages(s"structuresBuildingsAllowance.p5.$userType")</p>
 
         </div>
 

--- a/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsEligibleClaimView.scala.html
+++ b/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsEligibleClaimView.scala.html
@@ -33,8 +33,8 @@
 
     @heading(s"structuresBuildingsEligibleClaim.title.$userType")
 
-    <div class="govuk-body">
-        <p>@messages("structuresBuildingsEligibleClaim.p1")<p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages("structuresBuildingsEligibleClaim.p1")</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"structuresBuildingsEligibleClaim.l1.$userType")</li>
             <li>@messages("structuresBuildingsEligibleClaim.l2")

--- a/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsNewClaimAmountView.scala.html
+++ b/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsNewClaimAmountView.scala.html
@@ -37,17 +37,17 @@
 
     @heading("structuresBuildingsClaimedAmount.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>@messages(s"structuresBuildingsNewClaimAmount.p1.$userType")</p>
-        <p>@messages(s"structuresBuildingsNewClaimAmount.p.$userType")</p>
-        <p>@messages(s"structuresBuildingsNewClaimAmount.p2")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"structuresBuildingsNewClaimAmount.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"structuresBuildingsNewClaimAmount.p.$userType")</p>
+        <p class="govuk-body">@messages(s"structuresBuildingsNewClaimAmount.p2")</p>
 
-        <ul class="govuk-list--bullet">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"structuresBuildingsNewClaimAmount.l1")</li>
             <li>@messages(s"structuresBuildingsNewClaimAmount.l2")</li>
         </ul>
     <div>
-    <p>@messages(s"structuresBuildingsClaimedAmount.p4")
+    <p class="govuk-body">@messages(s"structuresBuildingsClaimedAmount.p4")
         <a class="govuk-link" target="_blank" href=@messages("structuresBuildingsClaimedAmount.href") >@messages("structuresBuildingsClaimedAmount.link")</a>
     </p>
     </div>

--- a/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsPreviousClaimUseView.scala.html
+++ b/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsPreviousClaimUseView.scala.html
@@ -33,17 +33,17 @@
 
     @heading(s"structuresBuildingsPreviousClaimUse.title.$userType")
 
-    <div class="govuk-body">
-        <p>@messages(s"structuresBuildingsPreviousClaimUse.p1.$userType")<p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"structuresBuildingsPreviousClaimUse.p1.$userType")</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages("structuresBuildingsPreviousClaimUse.l1")</li>
             <li>@messages("structuresBuildingsPreviousClaimUse.l2")</li>
         </ul>
-        <p>@messages(s"structuresBuildingsPreviousClaimUse.p2.$userType")<p>
-        <p>@messages(s"structuresBuildingsPreviousClaimUse.p3.$userType")
-    <a class="govuk-link" target="_blank" href=@messages("structuresBuildingsPreviousClaimUse.p3.href") >@messages("structuresBuildingsPreviousClaimUse.p3.link")</a>
-        @messages(s"structuresBuildingsPreviousClaimUse.p4")
-    </p>
+        <p class="govuk-body">@messages(s"structuresBuildingsPreviousClaimUse.p2.$userType")</p>
+        <p class="govuk-body">@messages(s"structuresBuildingsPreviousClaimUse.p3.$userType")
+            <a class="govuk-link" target="_blank" href=@messages("structuresBuildingsPreviousClaimUse.p3.href") >@messages("structuresBuildingsPreviousClaimUse.p3.link")</a>
+            @messages(s"structuresBuildingsPreviousClaimUse.p4")
+        </p>
         <a class="govuk-link" target="_blank" href=@messages("structuresBuildingsPreviousClaimUse.href") >@messages("structuresBuildingsPreviousClaimUse.link")</a>
 
     @formHelper(action = routes.StructuresBuildingsPreviousClaimUseController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsPreviousClaimedAmountView.scala.html
+++ b/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsPreviousClaimedAmountView.scala.html
@@ -37,22 +37,22 @@
 
     @heading("structuresBuildingsClaimedAmount.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>@messages(s"structuresBuildingsClaimedAmount.p1.$userType")</p>
-        <p>@messages(s"structuresBuildingsClaimedAmount.p2")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"structuresBuildingsClaimedAmount.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"structuresBuildingsClaimedAmount.p2")</p>
 
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"structuresBuildingsClaimedAmount.l1")</li>
             <li>@messages(s"structuresBuildingsClaimedAmount.l2")</li>
         </ul>
 
-        <p>@messages(s"structuresBuildingsClaimedAmount.p3")</p>
+        <p class="govuk-body">@messages(s"structuresBuildingsClaimedAmount.p3")</p>
 
-    <div>
-    <p>@messages(s"structuresBuildingsClaimedAmount.p4")
-        <a class="govuk-link" target="_blank" href=@messages("structuresBuildingsClaimedAmount.href") >@messages("structuresBuildingsClaimedAmount.link")</a>
-    </p>
-    </div>
+        <div>
+            <p class="govuk-body">@messages(s"structuresBuildingsClaimedAmount.p4")
+                <a class="govuk-link" target="_blank" href=@messages("structuresBuildingsClaimedAmount.href") >@messages("structuresBuildingsClaimedAmount.link")</a>
+            </p>
+        </div>
 
     </div>
 

--- a/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsQualifyingUseDateView.scala.html
+++ b/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsQualifyingUseDateView.scala.html
@@ -34,8 +34,8 @@
 
   @heading("structuresBuildingsQualifyingUseDate.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>@messages(s"structuresBuildingsQualifyingUseDate.p1")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"structuresBuildingsQualifyingUseDate.p1")</p>
     </div>
 
     @formHelper(action = routes.StructuresBuildingsQualifyingUseDateController.onSubmit(taxYear, businessId,index, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/capitalallowances/tailoring/ClaimCapitalAllowancesView.scala.html
+++ b/app/views/journeys/capitalallowances/tailoring/ClaimCapitalAllowancesView.scala.html
@@ -52,11 +52,11 @@
       @govukSummaryList(profitOrLossSummary)
     }
 
-    <div class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6">
-        <p>@messages(s"claimCapitalAllowances.p1.$userType.$accountingType")<p>
-        <p>@messages(s"claimCapitalAllowances.p2.$userType")<p>
-        <p>@messages(s"claimCapitalAllowances.p3.$userType.$accountingType")<p>
-        <p>@messages(s"claimCapitalAllowances.p4.$userType")<p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"claimCapitalAllowances.p1.$userType.$accountingType")</p>
+        <p class="govuk-body">@messages(s"claimCapitalAllowances.p2.$userType")</p>
+        <p class="govuk-body">@messages(s"claimCapitalAllowances.p3.$userType.$accountingType")</p>
+        <p class="govuk-body">@messages(s"claimCapitalAllowances.p4.$userType")</p>
     </div>
 
     @formHelper(action = routes.ClaimCapitalAllowancesController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/capitalallowances/writingDownAllowance/WdaMainRateClaimAmountView.scala.html
+++ b/app/views/journeys/capitalallowances/writingDownAllowance/WdaMainRateClaimAmountView.scala.html
@@ -33,23 +33,23 @@
     @errorSummary(form)
     @heading("wdaMainRateClaimAmount.heading")
 
-    <div class="govuk-body">
+    <div class="govuk-form-group">
         @foldableDetails(messages(s"wdaMainRateClaimAmount.details.$userType", "govuk-!-margin-bottom-3")) {
-            <p>@messages(s"wdaMainRateClaimAmount.p1.$userType")</p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <p class="govuk-body">@messages(s"wdaMainRateClaimAmount.p1.$userType")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("wdaMainRateClaimAmount.l1")</li>
                 <li>@messages(s"wdaMainRateClaimAmount.l2.$userType")</li>
             </ul>
-            <p>@messages(s"wdaMainRateClaimAmount.p2.$userType")</p>
-            <p>@messages("wdaMainRateClaimAmount.p3")</p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <p class="govuk-body">@messages(s"wdaMainRateClaimAmount.p2.$userType")</p>
+            <p class="govuk-body">@messages("wdaMainRateClaimAmount.p3")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("wdaMainRateClaimAmount.l3")</li>
                 <li>@messages(s"wdaMainRateClaimAmount.l4.$userType")</li>
                 <li>@messages(s"wdaMainRateClaimAmount.l5.$userType")</li>
             </ul>
-            <p>@messages(s"wdaMainRateClaimAmount.p4.$userType")</p>
-            <p>@messages("wdaMainRateClaimAmount.p5")</p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <p class="govuk-body">@messages(s"wdaMainRateClaimAmount.p4.$userType")</p>
+            <p class="govuk-body">@messages("wdaMainRateClaimAmount.p5")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages(s"wdaSpecialRateClaimAmount.l6.$userType")</li>
                 <li>@messages(s"wdaMainRateClaimAmount.l7.$userType")</li>
             </ul>

--- a/app/views/journeys/capitalallowances/writingDownAllowance/WdaMainRateView.scala.html
+++ b/app/views/journeys/capitalallowances/writingDownAllowance/WdaMainRateView.scala.html
@@ -31,9 +31,9 @@
     @errorSummary(form)
     @heading("wdaMainRate.heading")
 
-    <div class="govuk-body">
-        <p>@messages(s"wdaMainRate.p1.$userType")<p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"wdaMainRate.p1.$userType")</p>
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("wdaMainRate.l1")</li>
             <li>@messages(s"wdaMainRate.l2.$userType")</li>
         </ul>

--- a/app/views/journeys/capitalallowances/writingDownAllowance/WdaSingleAssetClaimAmountsView.scala.html
+++ b/app/views/journeys/capitalallowances/writingDownAllowance/WdaSingleAssetClaimAmountsView.scala.html
@@ -33,8 +33,8 @@
     @errorSummary(form)
     @heading("wdaSingleAssetClaimAmounts.heading")
 
-    <div class="govuk-body">
-        <p>@messages(s"wdaSingleAssetClaimAmounts.p1.$userType")<p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"wdaSingleAssetClaimAmounts.p1.$userType")</p>
 
         @formHelper(action = routes.WdaSingleAssetClaimAmountsController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
             @singleAmountContent(form) {

--- a/app/views/journeys/capitalallowances/writingDownAllowance/WdaSingleAssetView.scala.html
+++ b/app/views/journeys/capitalallowances/writingDownAllowance/WdaSingleAssetView.scala.html
@@ -28,15 +28,15 @@
 @(form: Form[_], mode: Mode, userType: UserType, taxYear: TaxYear, businessId: BusinessId)(implicit request: Request[_], messages: Messages)
 
 @description = {
-    <p>@messages(s"wdaSingleAsset.p2.$userType")<p>
+    <p class="govuk-body">@messages(s"wdaSingleAsset.p2.$userType")</p>
 }
 
 @layout(pageTitle = title(form, messages("wdaSingleAsset.heading"))) {
     @errorSummary(form)
     @heading("wdaSingleAsset.heading")
 
-    <div class="govuk-body">
-        <p>@messages(s"wdaSingleAsset.p1.$userType")<p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"wdaSingleAsset.p1.$userType")</p>
 
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"wdaSingleAsset.l1.$userType")</li>

--- a/app/views/journeys/capitalallowances/writingDownAllowance/WdaSpecialRateClaimAmountView.scala.html
+++ b/app/views/journeys/capitalallowances/writingDownAllowance/WdaSpecialRateClaimAmountView.scala.html
@@ -34,25 +34,25 @@
     @errorSummary(form)
     @heading("wdaSpecialRateClaimAmount.heading")
 
-    <div class="govuk-body">
-        <p>@messages("wdaSpecialRateClaimAmount.p1")<p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages("wdaSpecialRateClaimAmount.p1")</p>
 
         @foldableDetails(messages(s"wdaSpecialRateClaimAmount.details.$userType"), "govuk-!-margin-bottom-3") {
-            <p>@messages("wdaSpecialRateClaimAmount.p2")</p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <p class="govuk-body">@messages("wdaSpecialRateClaimAmount.p2")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("wdaSpecialRateClaimAmount.l1")</li>
                 <li>@messages(s"wdaSpecialRateClaimAmount.l2.$userType")</li>
             </ul>
-            <p>@messages(s"wdaSpecialRateClaimAmount.p3.$userType")</p>
-            <p>@messages("wdaSpecialRateClaimAmount.p4")</p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <p class="govuk-body">@messages(s"wdaSpecialRateClaimAmount.p3.$userType")</p>
+            <p class="govuk-body">@messages("wdaSpecialRateClaimAmount.p4")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages(s"wdaSpecialRateClaimAmount.l3.$userType")</li>
                 <li>@messages(s"wdaSpecialRateClaimAmount.l4.$userType")</li>
                 <li>@messages(s"wdaSpecialRateClaimAmount.l5.$userType")</li>
             </ul>
-            <p>@messages(s"wdaSpecialRateClaimAmount.p5.$userType")</p>
-            <p>@messages("wdaSpecialRateClaimAmount.p6")</p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <p class="govuk-body">@messages(s"wdaSpecialRateClaimAmount.p5.$userType")</p>
+            <p class="govuk-body">@messages("wdaSpecialRateClaimAmount.p6")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages(s"wdaSpecialRateClaimAmount.l6.$userType")</li>
                 <li>@messages(s"wdaSpecialRateClaimAmount.l7.$userType")</li>
             </ul>

--- a/app/views/journeys/capitalallowances/writingDownAllowance/WdaSpecialRateView.scala.html
+++ b/app/views/journeys/capitalallowances/writingDownAllowance/WdaSpecialRateView.scala.html
@@ -33,8 +33,8 @@
     @errorSummary(form)
     @heading("wdaSpecialRate.heading")
 
-    <div class="govuk-body">
-        <p>@messages(s"wdaSpecialRate.p1.$userType")<p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"wdaSpecialRate.p1.$userType")</p>
 
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages("wdaSpecialRate.l1")</li>

--- a/app/views/journeys/capitalallowances/writingDownAllowance/WritingDownAllowanceView.scala.html
+++ b/app/views/journeys/capitalallowances/writingDownAllowance/WritingDownAllowanceView.scala.html
@@ -29,13 +29,13 @@
 @layout(pageTitle = titleNoForm(messages("journeys.capital-allowances-writing-down-allowance"))) {
     @heading("writingDownAllowance.heading")
 
-    <div class="govuk-body">
-        <p>@messages(s"writingDownAllowance.p1.$userType")<p>
-        <p>@messages(s"writingDownAllowance.p2.$userType")<p>
-        <p>@messages(s"writingDownAllowance.p3.$userType")<p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"writingDownAllowance.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"writingDownAllowance.p2.$userType")</p>
+        <p class="govuk-body">@messages(s"writingDownAllowance.p3.$userType")</p>
 
         @subHeading("writingDownAllowance.h2")
-        <p>@messages(s"writingDownAllowance.p4.$userType")<p>
+        <p class="govuk-body">@messages(s"writingDownAllowance.p4.$userType")</p>
 
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"writingDownAllowance.l1.$userType")</li>

--- a/app/views/journeys/capitalallowances/zeroEmissionCars/ZecAllowanceView.scala.html
+++ b/app/views/journeys/capitalallowances/zeroEmissionCars/ZecAllowanceView.scala.html
@@ -36,14 +36,14 @@
 
     @heading("selectCapitalAllowances.zeroEmissionCar")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>@messages(s"zecAllowance.p1.$userType")</p>
-        <p>@messages(s"capitalAllowance.useFirstYearAllowance")</p>
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"zecAllowance.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"capitalAllowance.useFirstYearAllowance")</p>
+        <p class="govuk-body">
             <span class="govuk-!-font-weight-bold">@messages("capitalAllowance.inThisTaxYear")</span><br>
             @messages(s"zecAllowance.p3.$userType")
         </p>
-        <p>
+        <p class="govuk-body">
             <span class="govuk-!-font-weight-bold">@messages("capitalAllowance.multipleTaxYears")</span><br>
             @messages(s"zecAllowance.p4.$userType")
             @link(linkHrefKey = "capitalAllowance.linkHref", linkTextKey = "capitalAllowance.linkText")

--- a/app/views/journeys/capitalallowances/zeroEmissionCars/ZecHowMuchDoYouWantToClaimView.scala.html
+++ b/app/views/journeys/capitalallowances/zeroEmissionCars/ZecHowMuchDoYouWantToClaimView.scala.html
@@ -56,9 +56,9 @@
 
     @heading("capitalAllowance.claimingTheAllowance")
 
-    <div class="govuk-body">
-        <p>@messages(s"capitalAllowance.p1.$userType")</p>
-        <p>@messages(s"capitalAllowance.p2.$userType")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"capitalAllowance.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"capitalAllowance.p2.$userType")</p>
     </div>
 
     @formHelper(action = routes.ZecHowMuchDoYouWantToClaimController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/capitalallowances/zeroEmissionCars/ZeroEmissionCarsView.scala.html
+++ b/app/views/journeys/capitalallowances/zeroEmissionCars/ZeroEmissionCarsView.scala.html
@@ -33,8 +33,8 @@
 
     @heading("journeys.capital-allowances-zero-emission-cars")
 
-    <div class="govuk-body">
-        <p>@messages(s"zecUsedForWork.p1.$userType")<p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"zecUsedForWork.p1.$userType")</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"zecUsedForWork.l1.$userType")</li>
             <li>@messages(s"zecUsedForWork.l2.$userType")</li>
@@ -46,8 +46,8 @@
                 </span>
             </summary>
             <div class="govuk-details__text">
-                <p>@{messages(s"zecUsedForWork.details.p1.$userType")}</p>
-                <ul class="govuk-body govuk-list--bullet">
+                <p class="govuk-body">@{messages(s"zecUsedForWork.details.p1.$userType")}</p>
+                <ul class="govuk-list govuk-list--bullet">
                     <li>@{messages("zecUsedForWork.details.l1")}</li>
                     <li>@{messages("zecUsedForWork.details.l2")}</li>
                 </ul>

--- a/app/views/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZegvAllowanceView.scala.html
+++ b/app/views/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZegvAllowanceView.scala.html
@@ -37,14 +37,14 @@
     @heading(messages("selectCapitalAllowances.zeroEmissionGoodsVehicle"))
 
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>@messages(s"zegvAllowance.p1.$userType")</p>
-        <p>@messages(s"zegvAllowance.p2.$userType")</p>
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"zegvAllowance.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"zegvAllowance.p2.$userType")</p>
+        <p class="govuk-body">
             <span class="govuk-!-font-weight-bold">@messages("capitalAllowance.inThisTaxYear")</span><br>
             @messages(s"zegvAllowance.p3.$userType")
         </p>
-        <p>
+        <p class="govuk-body">
             <span class="govuk-!-font-weight-bold">@messages("capitalAllowance.multipleTaxYears")</span><br>
             @messages(s"zegvAllowance.p4.$userType")
             @link(linkHrefKey = "capitalAllowance.linkHref", linkTextKey = "capitalAllowance.linkText")

--- a/app/views/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZegvHowMuchDoYouWantToClaimView.scala.html
+++ b/app/views/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZegvHowMuchDoYouWantToClaimView.scala.html
@@ -64,10 +64,10 @@
 
     @heading("capitalAllowance.claimingTheAllowance")
 
-    <div class="govuk-body">
-        <p>@messages(s"capitalAllowance.p1.$userType")</p>
-        <p>@messages(s"capitalAllowance.p2.$userType")</p>
-        <p>@messages(s"zegvHowMuchDoYouWantToClaim.p3.$userType")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"capitalAllowance.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"capitalAllowance.p2.$userType")</p>
+        <p class="govuk-body">@messages(s"zegvHowMuchDoYouWantToClaim.p3.$userType")</p>
     </div>
 
     @formHelper(action = routes.ZegvHowMuchDoYouWantToClaimController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZeroEmissionGoodsVehiclesView.scala.html
+++ b/app/views/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZeroEmissionGoodsVehiclesView.scala.html
@@ -33,8 +33,8 @@
 
     @heading("journeys.capital-allowances-zero-emission-goods-vehicle")
 
-    <div class="govuk-body">
-        <p>@messages(s"zeroEmissionGoodsVehicle.p1.$userType")<p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"zeroEmissionGoodsVehicle.p1.$userType")</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"zeroEmissionGoodsVehicle.l1.$userType")</li>
             <li>@messages(s"zeroEmissionGoodsVehicle.l2.$userType")</li>
@@ -46,19 +46,19 @@
                 </span>
             </summary>
             <div class="govuk-details__text">
-                <p>@{messages(s"zeroEmissionGoodsVehicle.details.p1.$userType")}</p>
-                <ul class="govuk-body govuk-list--bullet">
+                <p class="govuk-body">@{messages(s"zeroEmissionGoodsVehicle.details.p1.$userType")}</p>
+                <ul class="govuk-list govuk-list--bullet">
                     <li>@{messages("zeroEmissionGoodsVehicle.details.l1")}</li>
                     <li>@{messages("zeroEmissionGoodsVehicle.details.l2")}</li>
                     <li>@{messages("zeroEmissionGoodsVehicle.details.l3")}</li>
                 </ul>
-                <p>@{messages("zeroEmissionGoodsVehicle.details.p2")}</p>
-                <p>@{messages("zeroEmissionGoodsVehicle.details.p3")}</p>
-                <ul class="govuk-body govuk-list--bullet">
+                <p class="govuk-body">@{messages("zeroEmissionGoodsVehicle.details.p2")}</p>
+                <p class="govuk-body">@{messages("zeroEmissionGoodsVehicle.details.p3")}</p>
+                <ul class="govuk-list govuk-list--bullet">
                     <li>@{messages("zeroEmissionGoodsVehicle.details.l4")}</li>
                     <li>@{messages("zeroEmissionGoodsVehicle.details.l5")}</li>
                 </ul>
-                <p>@{messages("zeroEmissionGoodsVehicle.details.p4")}</p>
+                <p class="govuk-body">@{messages("zeroEmissionGoodsVehicle.details.p4")}</p>
             </div>
         </details>
 

--- a/app/views/journeys/expenses/advertisingOrMarketing/AdvertisingAmountView.scala.html
+++ b/app/views/journeys/expenses/advertisingOrMarketing/AdvertisingAmountView.scala.html
@@ -49,15 +49,15 @@
                           </span>
                         </summary>
                         <div class="govuk-details__text">
-                            <p>${messages(s"site.canInclude.$userType")}</p>
-                            <ul class="govuk-body govuk-list--bullet">
+                            <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
+                            <ul class="govuk-list govuk-list--bullet">
                                 <li>${messages("advertisingOrMarketing.l1")}</li>
                                 <li>${messages("advertisingOrMarketing.l2")}</li>
                                 <li>${messages("advertisingOrMarketing.l3")}</li>
                                 <li>${messages("advertisingOrMarketing.l4")}</li>
                             </ul>
-                            <p>${messages(s"site.cannotInclude.$userType")}</p>
-                            <ul class="govuk-body govuk-list--bullet">
+                            <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
+                            <ul class="govuk-list govuk-list--bullet">
                                 <li>${messages("entertainmentCosts.l1")}</li>
                                 <li>${messages("entertainmentCosts.l2")}</li>
                             </ul>

--- a/app/views/journeys/expenses/construction/ConstructionIndustryAmountView.scala.html
+++ b/app/views/journeys/expenses/construction/ConstructionIndustryAmountView.scala.html
@@ -47,7 +47,7 @@
                                 ${messages(s"expenses.understanding.construction")} </span>
                         </summary>
                         <div class="govuk-details__text">
-                            <p>${messages(s"expenses.includes.construction.$userType")}</p>
+                            <p class="govuk-body">${messages(s"expenses.includes.construction.$userType")}</p>
                         </div>
                     </details>
                 """

--- a/app/views/journeys/expenses/depreciation/DepreciationDisallowableAmountView.scala.html
+++ b/app/views/journeys/expenses/depreciation/DepreciationDisallowableAmountView.scala.html
@@ -52,8 +52,8 @@
                                     </span>
                                 </summary>
                                 <div class="govuk-details__text">
-                                    <p>${messages(s"site.canInclude.$userType")}</p>
-                                    <ul class="govuk-body govuk-list--bullet">
+                                    <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
+                                    <ul class="govuk-list govuk-list--bullet">
                                         <li>${messages("depreciation.l1")}</li>
                                         <li>${messages("depreciation.l2")}</li>
                                     </ul>

--- a/app/views/journeys/expenses/financialCharges/FinancialChargesAmountView.scala.html
+++ b/app/views/journeys/expenses/financialCharges/FinancialChargesAmountView.scala.html
@@ -59,16 +59,16 @@
             <span class="govuk-details__summary-text"> @messages("financialExpenses.d2.heading")</span>
         </summary>
         <div class="govuk-details__text">
-            <p>@messages(s"site.canInclude.$user")</p>
-            <ul class="govuk-body govuk-list--bullet">
+            <p class="govuk-body">@messages(s"site.canInclude.$user")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("financialExpenses.d2.l1")</li>
                 <li>@messages("financialExpenses.d2.l2")</li>
                 <li>@messages("financialExpenses.d2.l3")</li>
                 <li>@messages("financialExpenses.d2.l4")</li>
                 <li>@messages("financialExpenses.d2.l5")</li>
             </ul>
-            <p>@messages(s"site.cannotInclude.$user")</p>
-            <ul class="govuk-body govuk-list--bullet">
+            <p class="govuk-body">@messages(s"site.cannotInclude.$user")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("financialExpenses.d2.l6")</li>
             </ul>
         </div>

--- a/app/views/journeys/expenses/goodsToSellOrUse/GoodsToSellOrUseAmountView.scala.html
+++ b/app/views/journeys/expenses/goodsToSellOrUse/GoodsToSellOrUseAmountView.scala.html
@@ -49,8 +49,8 @@
                           </span>
                         </summary>
                         <div class="govuk-details__text">
-                            <p>${messages(s"site.canInclude.$userType")}</p>
-                            <ul class="govuk-body govuk-list--bullet">
+                            <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
+                            <ul class="govuk-list govuk-list--bullet">
                                 ${if (taxiDriver) <li>{messages("expenses.fuelCosts")}</li> else ""}
                                 <li>${messages("expenses.costOfRawMaterials")}</li>
                                 ${if (accountingType == AccountingType.Cash) <li>{messages("expenses.stockBought")}</li> else ""}
@@ -59,8 +59,8 @@
                                 <li>${messages("expenses.commissions")}</li>
                                 <li>${messages("expenses.discounts")}</li>
                             </ul>
-                            <p>${messages(s"site.cannotInclude.$userType")}</p>
-                            <ul class="govuk-body govuk-list--bullet">
+                            <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
+                            <ul class="govuk-list govuk-list--bullet">
                                 ${if (accountingType == AccountingType.Cash) <li>{messages("expenses.costsForPrivateUse")}</li> else ""}
                                 <li>${messages("expenses.depreciationOfEquipment")}</li>
                             </ul>

--- a/app/views/journeys/expenses/interest/InterestAmountView.scala.html
+++ b/app/views/journeys/expenses/interest/InterestAmountView.scala.html
@@ -47,14 +47,14 @@
                                ${messages("expenses.understanding.interest")} </span>
                        </summary>
                        <div class="govuk-details__text">
-                           <p>${messages(s"site.canInclude.$userType")}</p>
-                           <ul class="govuk-body govuk-list--bullet">
+                           <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
+                           <ul class="govuk-list govuk-list--bullet">
                                <li>${messages(s"expenses.interest.${accountingType.entryName}")}</li>
                                <li>${messages("expenses.feesForBuyingGoods")}</li>
                                <li>${messages("expenses.hirePurchase")}</li>
                            </ul>
-                           <p>${messages(s"site.cannotInclude.$userType")}</p>
-                           <ul class="govuk-body govuk-list--bullet">
+                           <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
+                           <ul class="govuk-list govuk-list--bullet">
                                <li>${messages("expenses.repaymentsOfLoans")}</li>
                                <li>${messages("expenses.overdraftOrFinancialArrangements")}</li>
                            </ul>

--- a/app/views/journeys/expenses/irrecoverableDebts/IrrecoverableDebtsAmountView.scala.html
+++ b/app/views/journeys/expenses/irrecoverableDebts/IrrecoverableDebtsAmountView.scala.html
@@ -56,12 +56,12 @@
             <span class="govuk-details__summary-text"> @messages("financialExpenses.d3.heading")</span>
         </summary>
         <div class="govuk-details__text">
-            <p>@messages(s"site.canInclude.$user")</p>
-            <ul class="govuk-body govuk-list--bullet">
+            <p class="govuk-body">@messages(s"site.canInclude.$user")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("financialExpenses.d3.l1")</li>
             </ul>
-            <p>@messages(s"site.cannotInclude.$user")</p>
-            <ul class="govuk-body govuk-list--bullet">
+            <p class="govuk-body">@messages(s"site.cannotInclude.$user")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("expenses.debtsNotIncludedInTurnover")</li>
                 <li>@messages("expenses.debtsRelatingToFixedAssets")</li>
                 <li>@messages("expenses.generalBadDebts")</li>

--- a/app/views/journeys/expenses/officeSupplies/OfficeSuppliesAmountView.scala.html
+++ b/app/views/journeys/expenses/officeSupplies/OfficeSuppliesAmountView.scala.html
@@ -55,8 +55,8 @@
             <span class="govuk-details__summary-text"> @messages("officeSuppliesAmount.understandingOfficeSuppliesExpenses") </span>
         </summary>
         <div class="govuk-details__text">
-            <p>@messages(s"site.canInclude.$userType")</p>
-            <ul class="govuk-body govuk-list--bullet">
+            <p class="govuk-body">@messages(s"site.canInclude.$userType")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("officeSupplies.l1")</li>
                 <li>@messages("officeSupplies.l2")</li>
                 <li>@messages("officeSupplies.l3")</li>
@@ -66,8 +66,8 @@
                     <li>@messages("officeSupplies.l6")</li>
                 }
             </ul>
-            <p>@messages(s"site.cannotInclude.$userType")</p>
-            <ul class="govuk-body govuk-list--bullet">
+            <p class="govuk-body">@messages(s"site.cannotInclude.$userType")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 @if(accountingType == AccountingType.Cash) {
                     <li>@messages("expenses.listItem.anyAmount")</li>
                 } else {

--- a/app/views/journeys/expenses/otherExpenses/OtherExpensesAmountView.scala.html
+++ b/app/views/journeys/expenses/otherExpenses/OtherExpensesAmountView.scala.html
@@ -63,15 +63,15 @@
             <span class="govuk-details__summary-text"> @messages("otherExpensesAmount.understandingOtherExpenses")</span>
         </summary>
         <div class="govuk-details__text">
-            <p>@messages(s"site.canInclude.$user")</p>
-            <ul class="govuk-body govuk-list--bullet">
+            <p class="govuk-body">@messages(s"site.canInclude.$user")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("otherExpenses.l1")</li>
                 <li>@messages("otherExpenses.l2")</li>
             </ul>
             @tailoringAnswer match {
                 case YesAllowable => {
-                    <p>@messages(s"site.cannotInclude.$user")</p>
-                    <ul class="govuk-body govuk-list--bullet">
+                    <p class="govuk-body">@messages(s"site.cannotInclude.$user")</p>
+                    <ul class="govuk-list govuk-list--bullet">
                         <li>@messages("otherExpenses.l3")</li>
                         <li>@messages("otherExpenses.l4")</li>
                         <li>@messages("otherExpenses.l5")</li>

--- a/app/views/journeys/expenses/professionalFees/ProfessionalFeesAmountView.scala.html
+++ b/app/views/journeys/expenses/professionalFees/ProfessionalFeesAmountView.scala.html
@@ -48,16 +48,16 @@
                                ${messages("professionalServiceExpenses.d3.heading")} </span>
                        </summary>
                        <div class="govuk-details__text">
-                           <p>${messages(s"site.canIncludeFees.$userType")}</p>
-                           <ul class="govuk-body govuk-list--bullet">
+                           <p class="govuk-body">${messages(s"site.canIncludeFees.$userType")}</p>
+                           <ul class="govuk-list govuk-list--bullet">
                                <li>${messages("professionalServiceExpenses.d3.l1")}</li>
                                <li>${messages("professionalServiceExpenses.d3.l2")}</li>
                                <li>${messages("professionalServiceExpenses.d3.l3")}</li>
                                <li>${messages("professionalServiceExpenses.d3.l4")}</li>
                                <li>${messages("professionalServiceExpenses.d3.l5")}</li>
                            </ul>
-                           <p>${messages(s"site.cannotInclude.$userType")}</p>
-                           <ul class="govuk-body govuk-list--bullet">
+                           <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
+                           <ul class="govuk-list govuk-list--bullet">
                                <li>${messages("expenses.legalCost.property")}</li>
                                ${if(accountingType == Accrual) {
                                   <li>{messages("expenses.legalCost.equipment")}</li>

--- a/app/views/journeys/expenses/repairsandmaintenance/RepairsAndMaintenanceAmountView.scala.html
+++ b/app/views/journeys/expenses/repairsandmaintenance/RepairsAndMaintenanceAmountView.scala.html
@@ -44,15 +44,15 @@
             @heading(s"repairsAndMaintenanceAmount.title.$userType")
 
             @foldableDetails(messages("repairsAndMaintenanceAmount.details"), "govuk-!-margin-bottom-3") {
-                <p>@messages(s"site.canInclude.$userType")</p>
-                <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+                <p class="govuk-body">@messages(s"site.canInclude.$userType")</p>
+                <ul class="govuk-list govuk-list--bullet">
                     <li>@messages("repairsAndMaintenance.l1")</li>
                     @if(accountingType == AccountingType.Cash) {
                         <li>@messages("repairsAndMaintenance.l2")</li>
                     }
                 </ul>
-                <p>@messages(s"site.cannotInclude.$userType")</p>
-                <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+                <p class="govuk-body">@messages(s"site.cannotInclude.$userType")</p>
+                <ul class="govuk-list govuk-list--bullet">
                     <li>@messages("repairsAndMaintenance.l3")</li>
                     <li>@messages("repairsAndMaintenance.l4")</li>
                     @if(accountingType == AccountingType.Accrual) {

--- a/app/views/journeys/expenses/staffCosts/StaffCostsAmountView.scala.html
+++ b/app/views/journeys/expenses/staffCosts/StaffCostsAmountView.scala.html
@@ -50,8 +50,8 @@
                             </span>
                         </summary>
                         <div class="govuk-details__text">
-                            <p>${messages(s"site.canInclude.$userType")}</p>
-                            <ul class="govuk-body govuk-list--bullet">
+                            <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
+                            <ul class="govuk-list govuk-list--bullet">
                                 <li>${messages("expenses.salaries")}</li>
                                 <li>${messages("expenses.wages")}</li>
                                 <li>${messages("expenses.bonuses")}</li>
@@ -63,8 +63,8 @@
                             </ul>
                             ${if (isDisallowable) {
                                 s"""
-                                <p>${messages(s"site.cannotInclude.$userType")}</p>
-                                <ul class="govuk-body govuk-list--bullet">
+                                <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
+                                <ul class="govuk-list govuk-list--bullet">
                                     <li>${messages(s"expenses.contributions.$userType")}</li>
                                     <li>${messages("staffCosts.personalUse")}</li>
                                 </ul>

--- a/app/views/journeys/expenses/staffCosts/StaffCostsDisallowableAmountView.scala.html
+++ b/app/views/journeys/expenses/staffCosts/StaffCostsDisallowableAmountView.scala.html
@@ -46,8 +46,8 @@
                             </span>
                         </summary>
                         <div class="govuk-details__text">
-                            <p>@{messages("site.thisIncludes")}</p>
-                            <ul class="govuk-body govuk-list--bullet">
+                            <p class="govuk-body">@{messages("site.thisIncludes")}</p>
+                            <ul class="govuk-list govuk-list--bullet">
                                 <li>@{messages(s"expenses.contributions.$userType")}</li>
                                 <li>@{messages("staffCosts.personalUse")}</li>
                             </ul>

--- a/app/views/journeys/expenses/tailoring/ExpensesCategoriesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/ExpensesCategoriesView.scala.html
@@ -37,15 +37,15 @@
 
     @heading("journeys.expenses-categories")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>@messages(s"expensesCategories.p1.$userType")</p>
-        <p>@messages(s"expensesCategories.p2.$userType")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"expensesCategories.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"expensesCategories.p2.$userType")</p>
         @heading("expensesCategories.subHeading", headerSize = "m")
-        <p>@messages("expensesCategories.p3")</p>
+        <p class="govuk-body">@messages("expensesCategories.p3")</p>
 
         @foldableDetails(messages("expensesCategories.details.heading"), "govuk-!-margin-bottom-3") {
-            <p>@messages("expensesCategories.details.p1")</p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <p class="govuk-body">@messages("expensesCategories.details.p1")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("expenses.officeSupplies")</li>
                 <li>@messages("expenses.goodsToSellOrUse")</li>
                 <li>@messages("expenses.repairsAndMaintenance")</li>
@@ -57,7 +57,7 @@
                 <li>@messages("expenses.trainingCourses")</li>
                 <li>@messages("expenses.workClothing")</li>
             </ul>
-            <p>
+            <p class="govuk-body">
                 <a class="govuk-link" href=@messages("expensesCategories.details.href")>@messages("expensesCategories.details.link")</a>
             </p>
         }

--- a/app/views/journeys/expenses/tailoring/individualCategories/AdvertisingOrMarketingView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/AdvertisingOrMarketingView.scala.html
@@ -35,20 +35,20 @@
 
     @heading("advertisingOrMarketing.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
             @messages(s"site.canInclude.$userType")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("advertisingOrMarketing.l1")</li>
             <li>@messages("advertisingOrMarketing.l2")</li>
             <li>@messages("advertisingOrMarketing.l3")</li>
             <li>@messages("advertisingOrMarketing.l4")</li>
         </ul>
-        <p>
+        <p class="govuk-body">
             @messages(s"site.cannotInclude.$userType")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("expenses.listItem.anyAmount")</li>
         </ul>
     </div>

--- a/app/views/journeys/expenses/tailoring/individualCategories/DepreciationView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DepreciationView.scala.html
@@ -36,11 +36,11 @@
     @heading("depreciation.title")
 
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
             @messages(s"depreciation.p1.$userType")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("depreciation.l1")</li>
             <li>@messages("depreciation.l2")</li>
         </ul>

--- a/app/views/journeys/expenses/tailoring/individualCategories/DisallowableInterestView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DisallowableInterestView.scala.html
@@ -35,11 +35,11 @@
 
     @heading("disallowableInterest.heading")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
             @messages("site.theseInclude")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("expenses.repaymentsOfLoans")</li>
             <li>@messages("disallowableInterest.l2")</li>
         </ul>

--- a/app/views/journeys/expenses/tailoring/individualCategories/DisallowableIrrecoverableDebtsView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DisallowableIrrecoverableDebtsView.scala.html
@@ -35,11 +35,11 @@
 
     @heading("disallowableIrrecoverableDebts.heading")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
             @messages("site.theseInclude")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("expenses.debtsNotIncludedInTurnover")</li>
             <li>@messages("expenses.debtsRelatingToFixedAssets")</li>
             <li>@messages("expenses.generalBadDebts")</li>

--- a/app/views/journeys/expenses/tailoring/individualCategories/DisallowableOtherFinancialChargesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DisallowableOtherFinancialChargesView.scala.html
@@ -35,8 +35,8 @@
 
     @heading("disallowableOtherFinancialCharges.heading")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
             @messages("disallowableOtherFinancialCharges.p1")
         </p>
     </div>

--- a/app/views/journeys/expenses/tailoring/individualCategories/DisallowableProfessionalFeesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DisallowableProfessionalFeesView.scala.html
@@ -34,11 +34,11 @@
 
     @heading("disallowableProfessionalFees.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
         @messages(s"site.theseInclude")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("expenses.legalCost.property")</li>
             <li>@messages("expenses.legalCost.equipment")</li>
             <li>@messages("expenses.taxDisputes")</li>

--- a/app/views/journeys/expenses/tailoring/individualCategories/DisallowableStaffCostsView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DisallowableStaffCostsView.scala.html
@@ -34,11 +34,11 @@
 
     @heading("disallowableStaffCosts.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
         @messages(s"site.theseInclude")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             @if(userType.equals("individual")) {
                 <li>@messages(s"expenses.contributions.$userType")</li>
             } else {

--- a/app/views/journeys/expenses/tailoring/individualCategories/DisallowableSubcontractorCostsView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DisallowableSubcontractorCostsView.scala.html
@@ -34,8 +34,8 @@
 
     @heading("disallowableSubcontractorCosts.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
         @messages(s"disallowableSubcontractorCosts.p1.$userType")
         </p>
     </div>

--- a/app/views/journeys/expenses/tailoring/individualCategories/EntertainmentCostsView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/EntertainmentCostsView.scala.html
@@ -35,12 +35,12 @@
 
     @heading("journeys.expenses-entertainment")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
         @messages("expenses.hint.disallowableExpenses")
         @messages("site.theyInclude")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("entertainmentCosts.l1")</li>
             <li>@messages("entertainmentCosts.l2")</li>
         </ul>

--- a/app/views/journeys/expenses/tailoring/individualCategories/FinancialExpensesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/FinancialExpensesView.scala.html
@@ -44,18 +44,18 @@
                             </span>
         </summary>
         <div class="govuk-details__text">
-            <p>
+            <p class="govuk-body">
                 @messages(s"site.canInclude.$userType")
             </p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages(s"expenses.interest.${accountingType.entryName}")</li>
                 <li>@messages("expenses.feesForBuyingGoods")</li>
                 <li>@messages("expenses.hirePurchase")</li>
             </ul>
-            <p>
+            <p class="govuk-body">
                 @messages(s"site.cannotInclude.$userType")
             </p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("expenses.repaymentsOfLoans")</li>
                 <li>@messages("expenses.overdraftOrFinancialArrangements")</li>
             </ul>
@@ -69,20 +69,20 @@
                             </span>
         </summary>
         <div class="govuk-details__text">
-            <p>
+            <p class="govuk-body">
                 @messages(s"site.canInclude.$userType")
             </p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("financialExpenses.d2.l1")</li>
                 <li>@messages("financialExpenses.d2.l2")</li>
                 <li>@messages("financialExpenses.d2.l3")</li>
                 <li>@messages("financialExpenses.d2.l4")</li>
                 <li>@messages("financialExpenses.d2.l5")</li>
             </ul>
-            <p>
+            <p class="govuk-body">
                 @messages(s"site.cannotInclude.$userType")
             </p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("financialExpenses.d2.l6")</li>
             </ul>
         </div>
@@ -96,16 +96,16 @@
                                 </span>
             </summary>
             <div class="govuk-details__text">
-                <p>
+                <p class="govuk-body">
                     @messages(s"site.canInclude.$userType")
                 </p>
-                <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+                <ul class="govuk-list govuk-list--bullet">
                     <li>@messages("financialExpenses.d3.l1")</li>
                 </ul>
-                <p>
+                <p class="govuk-body">
                     @messages(s"site.cannotInclude.$userType")
                 </p>
-                <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+                <ul class="govuk-list govuk-list--bullet">
                     <li>@messages("expenses.debtsNotIncludedInTurnover")</li>
                     <li>@messages("expenses.debtsRelatingToFixedAssets")</li>
                     <li>@messages("expenses.generalBadDebts")</li>

--- a/app/views/journeys/expenses/tailoring/individualCategories/GoodsToSellOrUseView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/GoodsToSellOrUseView.scala.html
@@ -37,14 +37,14 @@
     @heading("journeys.expenses-goods-to-sell-or-use")
 
     <div class="govuk-inset-text">
-        <p>@messages("goodsToSellOrUse.insetText")</p>
+        <p class="govuk-body">@messages("goodsToSellOrUse.insetText")</p>
     </div>
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
         @messages(s"site.canInclude.$userType")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("expenses.fuelCosts")</li>
             <li>@messages("expenses.costOfRawMaterials")</li>
             <li>@messages("expenses.stockBought")</li>
@@ -56,10 +56,10 @@
             <li>@messages("expenses.discounts")</li>
 
         </ul>
-        <p>
+        <p class="govuk-body">
         @messages(s"site.cannotInclude.$userType")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
         @if(accountingType == AccountingType.Cash) {
             <li>@messages("expenses.costsForPrivateUse")</li>
 

--- a/app/views/journeys/expenses/tailoring/individualCategories/OfficeSuppliesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/OfficeSuppliesView.scala.html
@@ -36,11 +36,11 @@
 
     @heading("journeys.expenses-office-supplies")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
             @messages(s"site.canInclude.$userType")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("officeSupplies.l1")</li>
             <li>@messages("officeSupplies.l2")</li>
             <li>@messages("officeSupplies.l3")</li>
@@ -50,10 +50,10 @@
                 <li>@messages("officeSupplies.l6")</li>
             }
         </ul>
-        <p>
+        <p class="govuk-body">
             @messages(s"site.cannotInclude.$userType")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             @if(accountingType == AccountingType.Cash) {
                 <li>@messages("expenses.listItem.anyAmount")</li>
             } else {

--- a/app/views/journeys/expenses/tailoring/individualCategories/OtherExpensesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/OtherExpensesView.scala.html
@@ -36,18 +36,18 @@
 
     @heading("otherExpenses.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
             @messages(s"site.canInclude.$userType")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("otherExpenses.l1")</li>
             <li>@messages("otherExpenses.l2")</li>
         </ul>
-        <p>
+        <p class="govuk-body">
             @messages(s"site.cannotInclude.$userType")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("otherExpenses.l3")</li>
             <li>@messages("otherExpenses.l4")</li>
             <li>@messages("otherExpenses.l5")</li>

--- a/app/views/journeys/expenses/tailoring/individualCategories/ProfessionalServiceExpensesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/ProfessionalServiceExpensesView.scala.html
@@ -43,9 +43,10 @@
             </span>
         </summary>
         <div class="govuk-details__text">
-            @messages(s"site.canInclude.$userType")
+            <p class="govuk-body">
+                @messages(s"site.canInclude.$userType")
             </p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("expenses.salaries")</li>
                 <li>@messages("expenses.wages")</li>
                 <li>@messages("expenses.bonuses")</li>
@@ -55,10 +56,10 @@
                 <li>@messages("expenses.subcontractLabourCosts")</li>
                 <li>@messages("expenses.nationalInsuranceContributions")</li>
             </ul>
-            <p>
-            @messages(s"site.cannotInclude.$userType")
+            <p class="govuk-body">
+                @messages(s"site.cannotInclude.$userType")
             </p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages(s"expenses.contributions.$userType")</li>
                 <li>@messages("expenses.listItem.anyAmount")</li>
             </ul>
@@ -72,7 +73,7 @@
             </span>
         </summary>
         <div class="govuk-details__text">
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <ul class="govuk-list govuk-list--bullet">
                 <span>@messages(s"expenses.includes.construction.$userType")</span>
             </ul>
         </div>
@@ -85,19 +86,20 @@
             </span>
         </summary>
         <div class="govuk-details__text">
-            @messages(s"site.canInclude.$userType")
-        </p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <p class="govuk-body">
+                @messages(s"site.canInclude.$userType")
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("professionalServiceExpenses.d3.l1")</li>
                 <li>@messages("professionalServiceExpenses.d3.l2")</li>
                 <li>@messages("professionalServiceExpenses.d3.l3")</li>
                 <li>@messages("professionalServiceExpenses.d3.l4")</li>
                 <li>@messages("professionalServiceExpenses.d3.l5")</li>
             </ul>
-            <p>
-            @messages(s"site.cannotInclude.$userType")
+            <p class="govuk-body">
+                @messages(s"site.cannotInclude.$userType")
             </p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("expenses.legalCost.property")</li>
                     @if(accountingType == AccountingType.Accrual){
                         <li>@messages("expenses.legalCost.equipment")</li>

--- a/app/views/journeys/expenses/tailoring/individualCategories/RepairsAndMaintenanceView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/RepairsAndMaintenanceView.scala.html
@@ -36,20 +36,20 @@
 
     @heading("journeys.expenses-repairs-and-maintenance")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
             @messages(s"site.canInclude.$userType")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("repairsAndMaintenance.l1")</li>
             @if(accountingType == AccountingType.Cash){
                 <li>@messages("repairsAndMaintenance.l2")</li>
             }
         </ul>
-        <p>
+        <p class="govuk-body">
             @messages(s"site.cannotInclude.$userType")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("repairsAndMaintenance.l3")</li>
             <li>@messages("repairsAndMaintenance.l4")</li>
             @if(accountingType == AccountingType.Accrual){

--- a/app/views/journeys/expenses/tailoring/individualCategories/TravelForWorkView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/TravelForWorkView.scala.html
@@ -35,11 +35,11 @@
 
     @heading("travelForWork.title")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
         @messages(s"site.canInclude.$userType")
         </p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"travelForWork.l1.$userType")</li>
             <li>@messages("travelForWork.l2")</li>
             <li>@messages("travelForWork.l3")</li>
@@ -49,7 +49,7 @@
         </ul>
     </div>
     <div class="govuk-inset-text">
-        <p>@messages("travelForWork.insetText")</p>
+        <p class="govuk-body">@messages("travelForWork.insetText")</p>
     </div>
 
     @formHelper(action = controllers.journeys.expenses.tailoring.individualCategories.routes.TravelForWorkController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/expenses/travelAndAccommodation/CostsNotCoveredView.scala.html
+++ b/app/views/journeys/expenses/travelAndAccommodation/CostsNotCoveredView.scala.html
@@ -42,7 +42,7 @@
         @heading(s"costsNotCovered.title.common")
 
             <p class="govuk-body">@{messages(s"costsNotCovered.p1.$userType")}</p>
-            <ul class="govuk-body govuk-list--bullet">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@{messages("costsNotCovered.tolls.common")}</li>
                 <li>@{messages("costsNotCovered.congestion.common")}</li>
                 <li>@{messages("costsNotCovered.parking.common")}</li>

--- a/app/views/journeys/expenses/travelAndAccommodation/PublicTransportAndAccommodationExpensesView.scala.html
+++ b/app/views/journeys/expenses/travelAndAccommodation/PublicTransportAndAccommodationExpensesView.scala.html
@@ -41,14 +41,14 @@
 
         @heading(s"publicTransportAndAccommodationExpenses.heading.$userType")
             <p class="govuk-body">@{messages(s"publicTransportAndAccommodationExpenses.can.claim.$userType")}</p>
-                <ul class="govuk-body govuk-list--bullet">
-                    <li>@{messages(s"publicTransportAndAccommodationExpenses.can.claim.train-bus-air-taxi")}</li>
-                    <li>@{messages(s"publicTransportAndAccommodationExpenses.can.claim.hotel-room")}</li>
-                    <li>@{messages(s"publicTransportAndAccommodationExpenses.can.claim.meals-on-overnight-business-trips")}</li>
-                </ul>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>@{messages(s"publicTransportAndAccommodationExpenses.can.claim.train-bus-air-taxi")}</li>
+                <li>@{messages(s"publicTransportAndAccommodationExpenses.can.claim.hotel-room")}</li>
+                <li>@{messages(s"publicTransportAndAccommodationExpenses.can.claim.meals-on-overnight-business-trips")}</li>
+            </ul>
 
             <p class="govuk-body">@{messages(s"publicTransportAndAccommodationExpenses.cannot.claim.$userType")}</p>
-            <ul class="govuk-body govuk-list--bullet">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@{messages("publicTransportAndAccommodationExpenses.cannot.claim.personal-use")}</li>
                 <li>@{messages("publicTransportAndAccommodationExpenses.cannot.claim.travel-cost-home-work")}</li>
                 <li>@{messages("publicTransportAndAccommodationExpenses.cannot.claim.other-meals")}</li>

--- a/app/views/journeys/expenses/travelAndAccommodation/TravelForWorkYourMileageView.scala.html
+++ b/app/views/journeys/expenses/travelAndAccommodation/TravelForWorkYourMileageView.scala.html
@@ -42,8 +42,8 @@
 
         @heading(s"travelForWorkYourMileage.title.$userType")
 
-        <div class="govuk-body govuk-!-margin-bottom-6">
-            <p>@messages(s"travelForWorkYourMileage.p1.info.$userType", vehicle)</p>
+        <div class="govuk-form-group">
+            <p class="govuk-body">@messages(s"travelForWorkYourMileage.p1.info.$userType", vehicle)</p>
         </div>
 
         @govukInput(

--- a/app/views/journeys/expenses/travelAndAccommodation/TravelForWorkYourVehicleView.scala.html
+++ b/app/views/journeys/expenses/travelAndAccommodation/TravelForWorkYourVehicleView.scala.html
@@ -40,10 +40,10 @@
 
     @heading(s"travelForWorkYourVehicle.heading.$userType")
 
-        <div class="govuk-body govuk-!-margin-bottom-6">
-            <p>@messages(s"travelAndAccommodation.p1.info.$userType")</p>
-            <p>@messages(s"travelAndAccommodation.p2.info.$userType")</p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+        <div class="govuk-form-group">
+            <p class="govuk-body">@messages(s"travelAndAccommodation.p1.info.$userType")</p>
+            <p class="govuk-body">@messages(s"travelAndAccommodation.p2.info.$userType")</p>
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@messages(s"travelAndAccommodation.your-vehicle.l1")</li>
                 <li>@messages(s"travelAndAccommodation.your-vehicle.l2")</li>
                 <li>@messages(s"travelAndAccommodation.your-vehicle.l3")</li>

--- a/app/views/journeys/expenses/travelAndAccommodation/VehicleExpensesView.scala.html
+++ b/app/views/journeys/expenses/travelAndAccommodation/VehicleExpensesView.scala.html
@@ -47,7 +47,7 @@
         @heading(s"vehicleExpenses.title.$userType")
 
             <p class="govuk-body">@{messages(s"vehicleExpenses.can.claim.$userType")}</p>
-                <ul class="govuk-body govuk-list--bullet">
+                <ul class="govuk-list govuk-list--bullet">
                     <li>@{messages(s"vehicleExpenses.can.claim.insurance.common")}</li>
                     <li>@{messages("vehicleExpenses.can.claim.repairsAndServicing.common")}</li>
                     <li>@{messages("vehicleExpenses.can.claim.fuel.common")}</li>
@@ -60,7 +60,7 @@
                 </ul>
 
             <p class="govuk-body">@{messages(s"vehicleExpenses.cannot.claim.$userType")}</p>
-            <ul class="govuk-body govuk-list--bullet">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>@{messages("expenses.listItem.anyAmount")}</li>
                 <li>@{messages("vehicleExpenses.cannot.claim.fine.common")}</li>
                 @if(expenseType.contains(TravelAndAccommodationExpenseType.LeasedVehicles)) {

--- a/app/views/journeys/expenses/workplaceRunningCosts/workingFromBusinessPremises/BusinessPremisesAmountView.scala.html
+++ b/app/views/journeys/expenses/workplaceRunningCosts/workingFromBusinessPremises/BusinessPremisesAmountView.scala.html
@@ -42,25 +42,24 @@
         @singleAmountContent(form) {
             @heading("businessPremisesAmount.title")
 
-            <div class="govuk-body govuk-!-margin-top-6">
-                <p>
+            <div class="govuk-form-group">
+                <p class="govuk-body">
                 @messages(s"businessPremisesAmount.claim.$userType")
                 </p>
 
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
-            <li>@messages("businessPremisesAmount.rent")</li>
-            <li>@messages("businessPremisesAmount.businessAndWater")</li>
-            <li>@messages("businessPremisesAmount.lighting")</li>
-            <li>@messages("common.workplaceRunning.heating")</li>
-            <li>@messages("businessPremisesAmount.power")</li>
-            <li>@messages("businessPremisesAmount.insurance")</li>
-            <li>@messages("businessPremisesAmount.security")</li>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>@messages("businessPremisesAmount.rent")</li>
+                    <li>@messages("businessPremisesAmount.businessAndWater")</li>
+                    <li>@messages("businessPremisesAmount.lighting")</li>
+                    <li>@messages("common.workplaceRunning.heating")</li>
+                    <li>@messages("businessPremisesAmount.power")</li>
+                    <li>@messages("businessPremisesAmount.insurance")</li>
+                    <li>@messages("businessPremisesAmount.security")</li>
+                </ul>
 
-            </ul>
-
-          <P class="govuk-label govuk-label--m govuk-!-margin-bottom-4">
-             @messages(s"businessPremisesAmount.amount.$userType")
-            </P>
+                <P class="govuk-body">
+                 @messages(s"businessPremisesAmount.amount.$userType")
+                </P>
 
             </div>
 

--- a/app/views/journeys/expenses/workplaceRunningCosts/workingFromBusinessPremises/LiveAtBusinessPremisesView.scala.html
+++ b/app/views/journeys/expenses/workplaceRunningCosts/workingFromBusinessPremises/LiveAtBusinessPremisesView.scala.html
@@ -35,8 +35,8 @@
 
     @heading("liveAtBusinessPremises.heading")
 
-    <div class="govuk-body govuk-!-margin-top-6">
-        <p>@messages("liveAtBusinessPremises.l1")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages("liveAtBusinessPremises.l1")</p>
     </div>
 
     @formHelper(action = routes.LiveAtBusinessPremisesController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/expenses/workplaceRunningCosts/workingFromBusinessPremises/PeopleLivingAtBusinessPremisesView.scala.html
+++ b/app/views/journeys/expenses/workplaceRunningCosts/workingFromBusinessPremises/PeopleLivingAtBusinessPremisesView.scala.html
@@ -57,8 +57,8 @@
 
     @heading(s"peopleLivingAtBusinessPremises.title.$userType")
 
-    <div class="govuk-body">
-        <p>@messages(s"peopleLivingAtBusinessPremises.p1.$userType")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"peopleLivingAtBusinessPremises.p1.$userType")</p>
     </div>
 
     @formHelper(action = routes.PeopleLivingAtBusinessPremisesController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
@@ -66,9 +66,9 @@
         <fieldset class="govuk-fieldset">
             <div class=@{ if (wholeFormError) "govuk-form-group--error" else "" }>
 
-                <label class="govuk-label govuk-label--m">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                     @{messages(s"peopleLivingAtBusinessPremises.subHeading.$userType")}
-                </label>
+                </legend>
                 <div class="govuk-hint">
                     @{messages(s"peopleLivingAtBusinessPremises.hint.$userType", maxMonths)}
                 </div>

--- a/app/views/journeys/expenses/workplaceRunningCosts/workingFromHome/WfhClaimingAmountView.scala.html
+++ b/app/views/journeys/expenses/workplaceRunningCosts/workingFromHome/WfhClaimingAmountView.scala.html
@@ -37,16 +37,16 @@
 
     @heading(s"wfhClaimingAmount.title.$userType")
 
-    <div class="govuk-body">
-        <p>@messages(s"wfhClaimingAmount.p1.$userType")</p>
-        <ul class="govuk-list--bullet">
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"wfhClaimingAmount.p1.$userType")</p>
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("common.workplaceRunning.heating")</li>
             <li>@messages("wfhClaimingAmount.l2")</li>
             <li>@messages("wfhClaimingAmount.l3")</li>
             <li>@messages("wfhClaimingAmount.l4")</li>
         </ul>
-        <p>@messages(s"site.cannotInclude.$userType")</p>
-        <ul class="govuk-list--bullet">
+        <p class="govuk-body">@messages(s"site.cannotInclude.$userType")</p>
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("expenses.listItem.anyAmount")</li>
         </ul>
     </div>

--- a/app/views/journeys/expenses/workplaceRunningCosts/workingFromHome/WfhExpensesInfoView.scala.html
+++ b/app/views/journeys/expenses/workplaceRunningCosts/workingFromHome/WfhExpensesInfoView.scala.html
@@ -29,18 +29,18 @@
 
     @heading("wfhExpensesInfo.title")
 
-    <div class="govuk-body">
-        <p>@messages(s"wfhExpensesInfo.p1.$userType")</p>
-        <p>@messages(s"wfhExpensesInfo.p2.$userType")</p>
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"wfhExpensesInfo.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"wfhExpensesInfo.p2.$userType")</p>
+        <p class="govuk-body">
             <span class="govuk-!-font-weight-bold">@messages("site.example")</span>
             <br>
             @messages(s"wfhExpensesInfo.p3.$userType")
         </p>
-        <p>@messages(s"wfhExpensesInfo.p4.$userType")</p>
-        <p>@messages(s"wfhExpensesInfo.p5.$userType")</p>
+        <p class="govuk-body">@messages(s"wfhExpensesInfo.p4.$userType")</p>
+        <p class="govuk-body">@messages(s"wfhExpensesInfo.p5.$userType")</p>
 
-        <p>
+        <p class="govuk-body">
             @govukButton(ButtonViewModel(messages("site.continue")).asLink(nextRoute))
         </p>
     </div>

--- a/app/views/journeys/expenses/workplaceRunningCosts/workingFromHome/WorkingFromHomeHoursView.scala.html
+++ b/app/views/journeys/expenses/workplaceRunningCosts/workingFromHome/WorkingFromHomeHoursView.scala.html
@@ -57,10 +57,10 @@
 
     @heading(s"workingFromHomeHours.title.$userType")
 
-    <div class="govuk-body">
-        <p>@messages(s"workingFromHomeHours.p1.$userType")</p>
-        <p>@messages(s"workingFromHomeHours.p2.$userType")</p>
-        <p>@messages("workingFromHomeHours.p3")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"workingFromHomeHours.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"workingFromHomeHours.p2.$userType")</p>
+        <p class="govuk-body">@messages("workingFromHomeHours.p3")</p>
     </div>
 
     @formHelper(action = routes.WorkingFromHomeHoursController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
@@ -68,9 +68,9 @@
         <fieldset class="govuk-fieldset">
             <div class=@{ if (wholeFormError) "govuk-form-group--error" else "" }>
 
-                <label class="govuk-label govuk-label--m">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--M">
                     @{messages(s"workingFromHomeHours.subHeading.$userType")}
-                </label>
+                </legend>
                 <div class="govuk-hint">
                     @{messages(s"workingFromHomeHours.hint.$userType", maxMonths)}
                 </div>

--- a/app/views/journeys/income/HowMuchTradingAllowanceView.scala.html
+++ b/app/views/journeys/income/HowMuchTradingAllowanceView.scala.html
@@ -36,11 +36,11 @@
 
     @heading("howMuchTradingAllowance.title")
 
-    <div class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6">
-        <p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">
         @messages(s"howMuchTradingAllowance.p1.$userType")
         </p>
-        <p>
+        <p class="govuk-body">
         @messages("howMuchTradingAllowance.p2")
         </p>
     </div>

--- a/app/views/journeys/income/IncomeNotCountedAsTurnoverView.scala.html
+++ b/app/views/journeys/income/IncomeNotCountedAsTurnoverView.scala.html
@@ -35,13 +35,13 @@
 
     @heading("incomeNotCountedAsTurnover.title")
 
-    <div class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6">
-        <p>@messages(s"incomeNotCountedAsTurnover.p1.$userType")</p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"incomeNotCountedAsTurnover.p1.$userType")</p>
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"incomeNotCountedAsTurnover.l1.$userType")</li>
             <li>@messages(s"incomeNotCountedAsTurnover.l2.$userType")</li>
         </ul>
-        <p>@messages("incomeNotCountedAsTurnover.p2")</p>
+        <p class="govuk-body">@messages("incomeNotCountedAsTurnover.p2")</p>
     </div>
 
     @formHelper(action = routes.IncomeNotCountedAsTurnoverController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/income/TradingAllowanceView.scala.html
+++ b/app/views/journeys/income/TradingAllowanceView.scala.html
@@ -36,14 +36,14 @@
 @accrualDependentDetails = {
     @if(accountingType == AccountingType.Accrual){
         @foldableDetails(messages("capitalAllowances.understandingCapitalAllowances"), "govuk-!-margin-bottom-3") {
-            <p>@messages(s"capitalAllowances.p1.$userType")</p>
-            <p>@messages(s"capitalAllowances.p2.$userType")</p>
+            <p class="govuk-body">@messages(s"capitalAllowances.p1.$userType")</p>
+            <p class="govuk-body">@messages(s"capitalAllowances.p2.$userType")</p>
             <ul class="govuk-list govuk-list--bullet">
                 <li>@messages("capitalAllowances.l1")</li>
                 <li>@messages("capitalAllowances.l2")</li>
                 <li>@messages("capitalAllowances.l3")</li>
             </ul>
-            <p>@messages("capitalAllowances.p3")</p>
+            <p class="govuk-body">@messages("capitalAllowances.p3")</p>
         }
     }
 }
@@ -54,17 +54,17 @@
 
     @heading("tradingAllowance.title")
 
-    <div class="govuk-body">
-        <p>@messages(s"tradingAllowance.p1.$userType")</p>
-        <p>@messages(s"tradingAllowance.p2.$userType")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"tradingAllowance.p1.$userType")</p>
+        <p class="govuk-body">@messages(s"tradingAllowance.p2.$userType")</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages("tradingAllowance.l1")</li>
             <li>@messages("tradingAllowance.l2")</li>
         </ul>
         @accrualDependentDetails
-        <p>@messages(s"tradingAllowance.p3.$userType")</p>
-        <p>@messages(s"tradingAllowance.p4.$userType")</p>
-        <p>@messages(s"tradingAllowance.p5.$userType")</p>
+        <p class="govuk-body">@messages(s"tradingAllowance.p3.$userType")</p>
+        <p class="govuk-body">@messages(s"tradingAllowance.p4.$userType")</p>
+        <p class="govuk-body">@messages(s"tradingAllowance.p5.$userType")</p>
         @link("tradingAllowance.p6.href", s"tradingAllowance.p6.$userType")
     </div>
 

--- a/app/views/journeys/income/TurnoverIncomeAmountView.scala.html
+++ b/app/views/journeys/income/TurnoverIncomeAmountView.scala.html
@@ -37,9 +37,9 @@
 
     @heading("turnoverIncomeAmount.title")
 
-    <div class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-5">
-        <p>@messages(s"turnoverIncomeAmount.p1.$userType")</p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"turnoverIncomeAmount.p1.$userType")</p>
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("turnoverIncomeAmount.l1")</li>
             <li>@messages("turnoverIncomeAmount.l2")</li>
             <li>@messages("turnoverIncomeAmount.l3")</li>

--- a/app/views/journeys/income/TurnoverNotTaxableView.scala.html
+++ b/app/views/journeys/income/TurnoverNotTaxableView.scala.html
@@ -35,15 +35,15 @@
 
     @heading("turnoverNotTaxable.title")
 
-    <div class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6">
-        <p>@messages(s"turnoverNotTaxable.p1.$userType")</p>
-        <p>@messages("site.thisIncludes")</p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-1">
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"turnoverNotTaxable.p1.$userType")</p>
+        <p class="govuk-body">@messages("site.thisIncludes")</p>
+        <ul class="govuk-list govuk-list--bullet">
             <li>@messages("turnoverNotTaxable.l1")</li>
             <li>@messages("turnoverNotTaxable.l2")</li>
             <li>@messages("turnoverNotTaxable.l3")</li>
         </ul>
-        <p>@messages(s"turnoverNotTaxable.p3.$userType")</p>
+        <p class="govuk-body">@messages(s"turnoverNotTaxable.p3.$userType")</p>
     </div>
 
     @formHelper(action = routes.TurnoverNotTaxableController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {

--- a/app/views/journeys/nics/Class2NICsView.scala.html
+++ b/app/views/journeys/nics/Class2NICsView.scala.html
@@ -38,9 +38,9 @@
 
     @heading("class2NICs.title")
 
-    <div class="govuk-body govuk-!-margin-bottom-6">
-        <p>@messages(s"class2NICs.p1.$userType", getThresholdForTaxYearFormatted(taxYear))</p>
-        <p>@messages(s"class2NICs.p2.$userType")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"class2NICs.p1.$userType", getThresholdForTaxYearFormatted(taxYear))</p>
+        <p class="govuk-body">@messages(s"class2NICs.p2.$userType")</p>
     </div>
 
         @twoRadios(form, "class2NICs", userType, taxYear, inline = true)

--- a/app/views/journeys/nics/Class4NICsView.scala.html
+++ b/app/views/journeys/nics/Class4NICsView.scala.html
@@ -38,22 +38,18 @@
 
     @heading(s"class4NICs.title")
 
-    <div class="govuk-body govuk-!-margin-bottom-6">
-        <p>@messages(s"class4NICs.p1.$userType", getFiguresForTaxYearFormatted(taxYear, "lowerProfitsLimit"))</p>
-        <p>
-            @messages(s"class4NICs.p2.$userType", taxYear.startYear.toString, taxYear.toString)
-                <ul class="govuk-list govuk-list--bullet">
-                    <li>@messages(s"class4NICs.l1", getFiguresForTaxYearFormatted(taxYear, "rateBetweenLimits"), getFiguresForTaxYearFormatted(taxYear, "lowerProfitsLimit"), getFiguresForTaxYearFormatted(taxYear, "upperProfitsLimit"))</li>
-                    <li>@messages(s"class4NICs.l2", getFiguresForTaxYearFormatted(taxYear, "rateAboveUpperLimit"), getFiguresForTaxYearFormatted(taxYear, "upperProfitsLimit"))</li>
-                </ul>
-        </p>
-        <p>
-            @messages(s"class4NICs.p3.$userType")
-                <ul class="govuk-list govuk-list--bullet">
-                    <li>@messages(s"class4ExemptionReason.trusteeExecutorAdmin.$userType")</li>
-                    <li>@messages(s"class4NICs.l4.$userType")</li>
-                </ul>
-        </p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages(s"class4NICs.p1.$userType", getFiguresForTaxYearFormatted(taxYear, "lowerProfitsLimit"))</p>
+        <p class="govuk-body">@messages(s"class4NICs.p2.$userType", taxYear.startYear.toString, taxYear.toString)</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>@messages(s"class4NICs.l1", getFiguresForTaxYearFormatted(taxYear, "rateBetweenLimits"), getFiguresForTaxYearFormatted(taxYear, "lowerProfitsLimit"), getFiguresForTaxYearFormatted(taxYear, "upperProfitsLimit"))</li>
+            <li>@messages(s"class4NICs.l2", getFiguresForTaxYearFormatted(taxYear, "rateAboveUpperLimit"), getFiguresForTaxYearFormatted(taxYear, "upperProfitsLimit"))</li>
+        </ul>
+        <p class="govuk-body">@messages(s"class4NICs.p3.$userType")</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>@messages(s"class4ExemptionReason.trusteeExecutorAdmin.$userType")</li>
+            <li>@messages(s"class4NICs.l4.$userType")</li>
+        </ul>
     </div>
 
         @twoRadios(form, "class4NICs", userType, taxYear, inline = true)

--- a/app/views/templates/InternalServerErrorTemplate.scala.html
+++ b/app/views/templates/InternalServerErrorTemplate.scala.html
@@ -24,9 +24,9 @@
 
     @heading(messages("journeyRecovery.continue.title"), None, "govuk-!-margin-bottom-5", "xl")
 
-    <div class ="govuk-body">
-        <p class=>@messages("internal-server-error-template.paragraph.1")</p>
-        <p class=>@messages("error-template.paragraph.1.1")</p>
+    <div class ="govuk-form-group">
+        <p class="govuk-body">@messages("internal-server-error-template.paragraph.1")</p>
+        <p class="govuk-body">@messages("error-template.paragraph.1.1")</p>
     </div>
 
 


### PR DESCRIPTION
On several pages the paragraph class has wrongly been assigned to a parent divs and on occasion incorrectly to lists (ul's), causing layout and accessibility issues and as a result seen on pages the following issues:

- empty paragraphs being used to create spacing between block level elements
- additional non standard classes added to div, lists and paragraph to add the missing spacing which comes with using correct classes

Other fixes as part of this wok include:

-fixing broken closing tags for some paragraphs
-missing opening tags for some paragraphs
-removing non standard govuk margins (mostly added most likely as a result of the above issue) -adding in govuk-form-group - the class design to regulate design and -page flow chunks of content on more complexed pages -update some illegal labels inside fieldsets to legends -add in missing govuk-list classes from list