### PR TITLE
[SASS-11695] Add connector to Income-Tax-Session-Data

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -43,6 +43,7 @@ trait FrontendAppConfig {
   def countdown: Int
   def cacheTtl: Int
   def incomeTaxSubmissionBaseUrl: String
+  def vcSessionServiceBaseUrl: String
   def incomeTaxSubmissionIvRedirect: String
   def incomeTaxSubmissionStartUrl(taxYear: Int): String
   def viewAndChangeEnterUtrUrl: String
@@ -82,6 +83,8 @@ class FrontendAppConfigImpl @Inject() (configuration: Configuration, servicesCon
   )
 
   override val selfEmploymentBEBaseUrl: String = servicesConfig.baseUrl("income-tax-self-employment")
+
+  override val vcSessionServiceBaseUrl: String = servicesConfig.baseUrl("income-tax-session-data")
 
   override val timeout: Int   = configuration.get[Int]("timeout-dialog.timeout")
   override val countdown: Int = configuration.get[Int]("timeout-dialog.countdown")

--- a/app/connectors/SessionDataConnector.scala
+++ b/app/connectors/SessionDataConnector.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.FrontendAppConfig
+import models.errors.ServiceError
+import models.session.SessionData
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class SessionDataConnector @Inject() (config: FrontendAppConfig, httpClient: HttpClientV2)(implicit ec: ExecutionContext) {
+
+  implicit val sessionDataReads: OptionalContentHttpReads[SessionData] = new OptionalContentHttpReads[SessionData]
+
+  def getSessionData(implicit hc: HeaderCarrier): Future[Either[ServiceError, Option[SessionData]]] =
+    httpClient
+      .get(url"${config.vcSessionServiceBaseUrl}/income-tax-session-data")
+      .execute[Either[ServiceError, Option[SessionData]]]
+
+}

--- a/app/models/session/SessionData.scala
+++ b/app/models/session/SessionData.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.session
+
+import play.api.libs.json.{Format, Json}
+
+case class SessionData(sessionId: String, mtditid: String, nino: String, utr: Option[String] = None)
+
+object SessionData {
+  implicit val format: Format[SessionData] = Json.format[SessionData]
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -64,6 +64,12 @@ microservice {
       iv-redirect = "/iv-uplift"
     }
 
+    income-tax-session-data {
+      protocol = http
+      host     = localhost
+      port     = 30027
+    }
+
     view-and-change {
       url = "http://localhost:9081"
     }

--- a/it/connectors/SessionDataConnectorISpec.scala
+++ b/it/connectors/SessionDataConnectorISpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import base.IntegrationBaseSpec
+import helpers.WiremockSpec
+import models.errors.HttpErrorBody.SingleErrorBody
+import models.errors.ServiceError.{CannotReadJsonError, ConnectorResponseError}
+import models.errors.{HttpError, ServiceError}
+import models.session.SessionData
+import play.api.http.Status._
+import play.api.libs.json.{Json, __}
+
+class SessionDataConnectorISpec extends WiremockSpec with IntegrationBaseSpec {
+
+  lazy val connector: SessionDataConnector = app.injector.instanceOf[SessionDataConnector]
+
+  val stubGetUrl                       = s"/income-tax-session-data"
+  val sessionDataResponse: SessionData = SessionData(mtditid = mtditid.value, nino = nino.value, sessionId = sessionId)
+
+  type SessionDataResponse = Either[ServiceError, Option[SessionData]]
+
+  "calling .getSessionData()" should {
+
+    "return session data" when {
+
+      "downstream response is successful and includes valid JSON" in {
+        stubGetWithResponseBody(stubGetUrl, OK, Json.toJson(sessionDataResponse).toString())
+
+        val result: SessionDataResponse = connector.getSessionData(hc).futureValue
+        result mustBe Right(Some(sessionDataResponse))
+      }
+    }
+
+    "return None" when {
+
+      "downstream returns NOT_FOUND" in {
+        stubGetWithoutResponseBody(stubGetUrl, NOT_FOUND)
+
+        val result: SessionDataResponse = connector.getSessionData(hc).futureValue
+        result mustBe Right(None)
+      }
+
+      "downstream returns NO_CONTENT" in {
+        stubGetWithoutResponseBody(stubGetUrl, NO_CONTENT)
+
+        val result: SessionDataResponse = connector.getSessionData(hc).futureValue
+        result mustBe Right(None)
+      }
+    }
+
+    "return Left(error)" when {
+
+      "downstream returns OK but with an invalid response payload" in {
+        stubGetWithResponseBody(stubGetUrl, OK, "{}")
+
+        connector.getSessionData(hc).futureValue match {
+          case Left(value: CannotReadJsonError) =>
+            value.details.map(_._1) mustBe Seq(
+              __ \ "sessionId",
+              __ \ "nino",
+              __ \ "mtditid"
+            )
+          case Left(_)  => fail("Expected a CannotReadJsonError, but got a different error")
+          case Right(_) => fail("Expected a Left error response, but got a Right")
+        }
+      }
+
+      "downstream fails with Internal Error" in {
+
+        val apiError = SingleErrorBody("INTERNAL_SERVER_ERROR", "Internal server error")
+        stubGetWithResponseBody(stubGetUrl, INTERNAL_SERVER_ERROR, Json.toJson(apiError).toString())
+
+        connector.getSessionData(hc).futureValue match {
+          case Left(value) =>
+            value mustBe ConnectorResponseError(
+              method = "GET",
+              url = s"http://localhost:$wireMockPort/income-tax-session-data",
+              originalHttpError = HttpError(INTERNAL_SERVER_ERROR, apiError)
+            )
+          case Left(_)  => fail("Expected a ConnectorResponseError, but got a different error")
+          case Right(_) => fail("Expected a Left error response, but got a Right")
+        }
+      }
+
+      "downstream returns SERVICE_UNAVAILABLE" in {
+
+        val apiError = SingleErrorBody("SERVICE_UNAVAILABLE", "Service unavailable error")
+        stubGetWithResponseBody(stubGetUrl, SERVICE_UNAVAILABLE, Json.toJson(apiError).toString())
+
+        connector.getSessionData(hc).futureValue match {
+          case Left(value) =>
+            value mustBe ConnectorResponseError(
+              method = "GET",
+              url = s"http://localhost:$wireMockPort/income-tax-session-data",
+              originalHttpError = HttpError(SERVICE_UNAVAILABLE, apiError)
+            )
+          case Left(_)  => fail("Expected a ConnectorResponseError, but got a different error")
+          case Right(_) => fail("Expected a Left error response, but got a Right")
+        }
+      }
+
+      "downstream fails with unknown error" in {
+
+        val apiError = SingleErrorBody("TOO_MANY_REQUESTS", "Service unavailable error")
+        stubGetWithResponseBody(stubGetUrl, TOO_MANY_REQUESTS, Json.toJson(apiError).toString())
+
+        connector.getSessionData(hc).futureValue match {
+          case Left(value) =>
+            value mustBe ConnectorResponseError(
+              method = "GET",
+              url = s"http://localhost:$wireMockPort/income-tax-session-data",
+              originalHttpError = HttpError(INTERNAL_SERVER_ERROR, apiError)
+            )
+          case Left(_)  => fail("Expected a ConnectorResponseError, but got a different error")
+          case Right(_) => fail("Expected a Left error response, but got a Right")
+        }
+      }
+    }
+  }
+}

--- a/it/helpers/WiremockSpec.scala
+++ b/it/helpers/WiremockSpec.scala
@@ -44,7 +44,12 @@ trait WiremockSpec
   val wireMockPort                   = 11111
   val wireMockServer: WireMockServer = new WireMockServer(wireMockConfig().port(wireMockPort))
 
-  lazy val connectedServices: Seq[String] = Seq("auth", "integration-framework", "income-tax-self-employment")
+  lazy val connectedServices: Seq[String] = Seq(
+    "auth",
+    "integration-framework",
+    "income-tax-self-employment",
+    "income-tax-session-data"
+  )
 
   def servicesToUrlConfig: Seq[(String, String)] = connectedServices
     .flatMap(service =>

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.11.0"
+  private val bootstrapVersion = "9.12.0"
   private val hmrcMongoVersion = "2.6.0"
 
   val jacksonAndPlayExclusions: Seq[InclusionRule] = Seq(
@@ -15,7 +15,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"        %% "play-frontend-hmrc-play-30"            % bootstrapVersion,
+    "uk.gov.hmrc"        %% "play-frontend-hmrc-play-30"            % "12.2.0",
     "uk.gov.hmrc"        %% "play-conditional-form-mapping-play-30" % "3.3.0",
     "uk.gov.hmrc"        %% "bootstrap-frontend-play-30"            % bootstrapVersion,
     "uk.gov.hmrc.mongo"  %% "hmrc-mongo-play-30"                    % hmrcMongoVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 
 addSbtPlugin("uk.gov.hmrc"        % "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"        % "sbt-distributables"    % "2.6.0")
-addSbtPlugin("org.playframework"  % "sbt-plugin"            % "3.0.6")
+addSbtPlugin("org.playframework"  % "sbt-plugin"            % "3.0.7")
 addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin" % "1.0.0" exclude ("org.scala-lang.modules", "scala-xml_2.12"))
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"         % "2.3.1")
 addSbtPlugin("io.github.irundaia" % "sbt-sassify"           % "1.5.2")

--- a/test/forms/expenses/travelAndAccommodation/VehicleExpensesFormProviderSpec.scala
+++ b/test/forms/expenses/travelAndAccommodation/VehicleExpensesFormProviderSpec.scala
@@ -20,7 +20,7 @@ import forms.behaviours.BigDecimalFieldBehaviours
 import models.common.UserType
 import play.api.data.FormError
 
-import scala.collection.compat.immutable.ArraySeq
+import scala.collection.immutable.ArraySeq
 
 class VehicleExpensesFormProviderSpec extends BigDecimalFieldBehaviours {
 


### PR DESCRIPTION
Note, I've fitted this into the repos existing generic reads to keep it consistent with the existing Http Reads handling they have - but I've switched this connector to `HTTPClientV2`.

App-Config-Base PR:
- https://github.com/hmrc/app-config-base/pull/12145