### PR TITLE
Fix various accessibility issues with h1's

### DIFF
--- a/app/views/components/Heading2.scala.html
+++ b/app/views/components/Heading2.scala.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(value: String, headingArgs: Option[String] = None, extraHeadingClasses: String = "", headerSize: String = "m")(implicit messages: Messages)
+
+<h2 class=@{s"govuk-heading-$headerSize $extraHeadingClasses"}>@{headingArgs.fold(messages(value))(messages(value, _))}</h2>

--- a/app/views/journeys/abroad/SelfEmploymentAbroadView.scala.html
+++ b/app/views/journeys/abroad/SelfEmploymentAbroadView.scala.html
@@ -17,6 +17,7 @@
 @import controllers.journeys.abroad.routes
 @import models.common.{BusinessId, TaxYear, UserType}
 @import views.html.components.{ErrorSummarySection, Heading, SubmitButton}
+@import viewmodels.LegendSize.Large
 
 @this(
         layout: templates.Layout,
@@ -35,12 +36,10 @@
 
         @errorSummarySection(form)
 
-        @heading(s"selfEmploymentAbroad.title.$userType")
-
         @govukRadios(
             RadiosViewModel.yesNoVertical(
                 field = form("value"),
-                legend = LegendViewModel("")
+                legend = LegendViewModel(messages(s"selfEmploymentAbroad.title.$userType")).asPageHeading(Large)
             )
         )
 

--- a/app/views/journeys/adjustments/profitOrLoss/GoodsAndServicesAmountView.scala.html
+++ b/app/views/journeys/adjustments/profitOrLoss/GoodsAndServicesAmountView.scala.html
@@ -16,16 +16,16 @@
 
 @import controllers.journeys.adjustments.profitOrLoss.routes
 @import models.common.{AccountingType, BusinessId, TaxYear, UserType}
+@import viewmodels.InputWidth._
+@import viewmodels.LabelSize
 @import views.html.components._
 
 @this(
         layout: templates.Layout,
         formHelper: FormWithCSRF,
         errorSummarySection: ErrorSummarySection,
-        singleAmountContent: SingleAmountContent,
-        submitButton: SubmitButton,
-        heading: Heading,
-        headingWithHint: HeadingWithHint
+        govukInput: GovukInput,
+        submitButton: SubmitButton
 )
 
 @(form: Form[_], taxYear: TaxYear, businessId: BusinessId, userType: UserType, mode: Mode, accountingType: AccountingType)(implicit request: Request[_], messages: Messages)
@@ -36,17 +36,32 @@
 
     @formHelper(action = routes.GoodsAndServicesAmountController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
-        @{
-            if(accountingType == AccountingType.Cash) {
-                singleAmountContent(form) {
-                    headingWithHint(s"goodsAndServicesAmount.title.cash.$userType", s"goodsAndServicesAmount.caption.$userType", extraHeadingClasses = "govuk-!-margin-bottom-2")
-                }
-            } else {
-                singleAmountContent(form) {
-                    heading(s"goodsAndServicesAmount.title.$userType", extraHeadingClasses = "govuk-!-margin-bottom-3")
-                }
-            }
+        @if(accountingType == AccountingType.Cash) {
+            @govukInput(
+                InputViewModel(
+                    field = form("value"),
+                    label = LabelViewModel(messages(s"goodsAndServicesAmount.title.cash.$userType"))
+                    .asPageHeading(size = LabelSize.Large)
+                )
+                .asNumeric()
+                .withHint(HintViewModel(messages("site.hint.amount")))
+                .withWidth(Fixed10)
+                .withPrefix(PrefixOrSuffix(content = Text("£")))
+            )
+        } else {
+            @govukInput(
+                InputViewModel(
+                    field = form("value"),
+                    label = LabelViewModel(messages(s"goodsAndServicesAmount.title.$userType"))
+                    .asPageHeading(size = LabelSize.Large)
+                )
+                .asNumeric()
+                .withHint(HintViewModel(messages("site.hint.amount")))
+                .withWidth(Fixed10)
+                .withPrefix(PrefixOrSuffix(content = Text("£")))
+            )
         }
+
 
         @submitButton()
     }

--- a/app/views/journeys/adjustments/profitOrLoss/GoodsAndServicesForYourOwnUseView.scala.html
+++ b/app/views/journeys/adjustments/profitOrLoss/GoodsAndServicesForYourOwnUseView.scala.html
@@ -23,18 +23,13 @@
         layout: templates.Layout,
         formHelper: FormWithCSRF,
         errorSummarySection: ErrorSummarySection,
-        twoRadios: TwoRadios,
+        govukRadios: GovukRadios,
         submitButton: SubmitButton,
         heading: Heading
 )
 
 @(form: Form[_], taxYear: TaxYear, businessId: BusinessId, userType: UserType, mode: Mode, accountingType: AccountingType)(implicit request: Request[_], messages: Messages)
 
-@hintText = {
-    <div class="govuk-hint">
-    @messages(s"goodsAndServicesForYourOwnUse.hint.$userType")
-    </div>
-}
 
 @layout(pageTitle = title(form, messages(s"goodsAndServicesForYourOwnUse.title.$userType"))) {
 
@@ -52,7 +47,14 @@
 
     @formHelper(action = routes.GoodsAndServicesForYourOwnUseController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
-        @twoRadios(form, "goodsAndServicesForYourOwnUse", userType, taxYear, hintText, inline = false)
+        @govukRadios(
+            RadiosViewModel.yesNoWithLabel(
+                field = form("value"),
+                legend = LegendViewModel(messages(s"goodsAndServicesForYourOwnUse.subHeading.$userType"))
+                .withCssClass("govuk-fieldset__legend--m"),
+                inline = false
+            ).withHint(HintViewModel(messages(s"goodsAndServicesForYourOwnUse.hint.$userType")))
+        )
 
         @submitButton()
     }

--- a/app/views/journeys/adjustments/profitOrLoss/PreviousUnusedLossesView.scala.html
+++ b/app/views/journeys/adjustments/profitOrLoss/PreviousUnusedLossesView.scala.html
@@ -16,6 +16,7 @@
 
 @import controllers.journeys.adjustments.profitOrLoss.routes
 @import models.common.{BusinessId, TaxYear, UserType}
+@import viewmodels.LegendSize
 @import views.html.components._
 
 @import models.common.TradingName
@@ -24,18 +25,12 @@
         layout: templates.Layout,
         formHelper: FormWithCSRF,
         errorSummarySection: ErrorSummarySection,
-        twoRadios: TwoRadios,
-        submitButton: SubmitButton,
-        heading: Heading
+        govukRadios: GovukRadios,
+        submitButton: SubmitButton
 )
 
 @(form: Form[_], taxYear: TaxYear, businessId: BusinessId, tradingName: TradingName ,userType: UserType, mode: Mode)(implicit request: Request[_], messages: Messages)
 
-@legend= {
-    <label class="govuk-hint">
-    @messages(s"previousUnusedLosses.subHeading.$userType")
-    </label>
-}
 
 @layout(pageTitle = title(form, messages("previousUnusedLosses.title", tradingName))) {
 
@@ -43,9 +38,13 @@
 
     @formHelper(action = routes.PreviousUnusedLossesController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
-        @heading("previousUnusedLosses.title", Some(tradingName.value))
-
-        @twoRadios(form, "PreviousUnusedLosses", userType, taxYear, inline = true, legend = Some(legend))
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("previousUnusedLosses.title", tradingName.value))
+                .asPageHeading(size = LegendSize.Large)
+            ).withHint(HintViewModel(messages(s"previousUnusedLosses.subHeading.$userType")))
+        )
 
         @submitButton()
     }

--- a/app/views/journeys/adjustments/profitOrLoss/UnusedLossAmountView.scala.html
+++ b/app/views/journeys/adjustments/profitOrLoss/UnusedLossAmountView.scala.html
@@ -16,15 +16,16 @@
 
 @import controllers.journeys.adjustments.profitOrLoss.routes
 @import models.common.{BusinessId, TaxYear, UserType}
+@import viewmodels.InputWidth._
+@import viewmodels.LabelSize
 @import views.html.components._
 
 @this(
         layout: templates.Layout,
         formHelper: FormWithCSRF,
         errorSummarySection: ErrorSummarySection,
-        singleAmountContent: SingleAmountContent,
-        submitButton: SubmitButton,
-        heading: Heading
+        govukInput: GovukInput,
+        submitButton: SubmitButton
 )
 
 @(form: Form[_], taxYear: TaxYear, businessId: BusinessId, mode: Mode)(implicit request: Request[_], messages: Messages)
@@ -35,9 +36,17 @@
 
     @formHelper(action = routes.UnusedLossAmountController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
-        @singleAmountContent(form) {
-            @heading("unusedLossAmount.title")
-        }
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = LabelViewModel(messages("unusedLossAmount.title"))
+                .asPageHeading(size = LabelSize.Large)
+            )
+            .asNumeric()
+            .withHint(HintViewModel(messages("site.hint.amount")))
+            .withWidth(Fixed10)
+            .withPrefix(PrefixOrSuffix(content = Text("£")))
+        )
 
         @submitButton()
     }

--- a/app/views/journeys/adjustments/profitOrLoss/WhatDoYouWantToDoWithLossView.scala.html
+++ b/app/views/journeys/adjustments/profitOrLoss/WhatDoYouWantToDoWithLossView.scala.html
@@ -17,6 +17,7 @@
 @import controllers.journeys.adjustments.profitOrLoss.routes
 @import models.common.{BusinessId, TaxYear, UserType}
 @import models.journeys.adjustments.WhatDoYouWantToDoWithLoss
+@import viewmodels.LegendSize
 @import views.html.components._
 
 @this(
@@ -24,8 +25,7 @@
         formHelper: FormWithCSRF,
         errorSummarySection: ErrorSummarySection,
         govukCheckboxes: GovukCheckboxes,
-        submitButton: SubmitButton,
-        heading: Heading
+        submitButton: SubmitButton
 )
 
 @(form: Form[_], taxYear: TaxYear, businessId: BusinessId, userType: UserType, mode: Mode)(implicit request: Request[_], messages: Messages)
@@ -36,19 +36,14 @@
 
     @formHelper(action = routes.CurrentYearLossController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
-        @heading(messages(s"whatDoYouWantToDoWithLoss.title.$userType", taxYear.startYear.toString, taxYear.endYear.toString))
-
-        <div class="govuk-hint">@messages("whatDoYouWantToDoWithLoss.selectOptions")</div>
-
         @govukCheckboxes(
             CheckboxesViewModel(
                 form = form,
                 name = "value",
                 items = WhatDoYouWantToDoWithLoss.options(),
-                legend = Legend(
-                    classes = "govuk-fieldset__legend--l"
-                )
-            )
+                legend = LegendViewModel(messages(s"whatDoYouWantToDoWithLoss.title.$userType", taxYear.startYear.toString, taxYear.endYear.toString))
+                .asPageHeading(size = LegendSize.Large)
+            ).withHint(Some(HintViewModel(messages("whatDoYouWantToDoWithLoss.selectOptions"))))
         )
 
         @submitButton()

--- a/app/views/journeys/adjustments/profitOrLoss/WhichYearIsLossReportedView.scala.html
+++ b/app/views/journeys/adjustments/profitOrLoss/WhichYearIsLossReportedView.scala.html
@@ -47,7 +47,7 @@
             RadiosViewModel(
                 field  = form("value"),
                 legend = LegendViewModel(messages(s"whichYearIsLossReported.subHeading.$userType", undefinedLossValue))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m"),
+                .withCssClass("govuk-fieldset__legend--m"),
                 items  = WhichYearIsLossReported.options()
             )
         )

--- a/app/views/journeys/capitalallowances/annualInvestmentAllowance/AnnualInvestmentAllowanceView.scala.html
+++ b/app/views/journeys/capitalallowances/annualInvestmentAllowance/AnnualInvestmentAllowanceView.scala.html
@@ -62,7 +62,7 @@
             RadiosViewModel.yesNo(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"annualInvestmentAllowance.subHeading.$userType", taxYear.startYear.toString, taxYear.endYear.toString))
-                .withCssClass("govuk-fieldset__legend--m govuk-!-margin-bottom-6"))
+                .withCssClass("govuk-fieldset__legend--m"))
         )
 
         @submitButton()

--- a/app/views/journeys/capitalallowances/balancingAllowance/BalancingAllowanceView.scala.html
+++ b/app/views/journeys/capitalallowances/balancingAllowance/BalancingAllowanceView.scala.html
@@ -58,7 +58,7 @@
             RadiosViewModel.yesNo(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"balancingAllowance.subHeading.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m"))
+                .withCssClass("govuk-fieldset__legend--m"))
         )
 
         @submitButton()

--- a/app/views/journeys/capitalallowances/balancingCharge/BalancingChargeView.scala.html
+++ b/app/views/journeys/capitalallowances/balancingCharge/BalancingChargeView.scala.html
@@ -57,7 +57,7 @@
             RadiosViewModel.yesNo(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"balancingCharge.subHeading.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m"))
+                .withCssClass("govuk-fieldset__legend--m"))
         )
 
         @submitButton()

--- a/app/views/journeys/capitalallowances/specialTaxSites/ContinueClaimingAllowanceForExistingSiteView.scala.html
+++ b/app/views/journeys/capitalallowances/specialTaxSites/ContinueClaimingAllowanceForExistingSiteView.scala.html
@@ -16,7 +16,7 @@
 
 @import controllers.journeys.capitalallowances.specialTaxSites.routes
 @import models.common.{BusinessId, TaxYear, UserType}
-@import views.html.components.{SubmitButton, YesNoWithHeadingAndHint, Heading, ErrorSummarySection}
+@import views.html.components.{SubmitButton, Heading, ErrorSummarySection}
 @import viewmodels.LegendSize.Medium
 
 @this(layout: templates.Layout,
@@ -24,7 +24,6 @@
         errorSummarySection: ErrorSummarySection,
         heading: Heading,
         govukRadios: GovukRadios,
-        yesNoWithHeadingAndHint: YesNoWithHeadingAndHint,
         submitButton: SubmitButton)
 
 @(form: Form[_], mode: Mode, userType: UserType, taxYear: TaxYear, businessId: BusinessId)(implicit request: Request[_], messages: Messages)
@@ -51,7 +50,7 @@
             RadiosViewModel.yesNo(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"continueClaimingAllowanceForExistingSite.subHeading.$userType"))
-                .asPageHeading(size = Medium)
+                .withCssClass("govuk-fieldset__legend--m"))
             )
         )
 

--- a/app/views/journeys/capitalallowances/specialTaxSites/ContractForBuildingConstructionView.scala.html
+++ b/app/views/journeys/capitalallowances/specialTaxSites/ContractForBuildingConstructionView.scala.html
@@ -16,7 +16,6 @@
 
 @import controllers.journeys.capitalallowances.specialTaxSites.routes
 @import models.common.{BusinessId, TaxYear, UserType}
-@import viewmodels.LegendSize.Medium
 @import views.html.components._
 
 @this(layout: templates.Layout,
@@ -48,7 +47,7 @@
             RadiosViewModel.yesNo(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"contractForBuildingConstruction.subHeading.$userType"))
-                .asPageHeading(size = Medium)
+                .withCssClass("govuk-fieldset__legend--m"))
             )
         )
         @submitButton()

--- a/app/views/journeys/capitalallowances/specialTaxSites/SpecialTaxSiteLocationView.scala.html
+++ b/app/views/journeys/capitalallowances/specialTaxSites/SpecialTaxSiteLocationView.scala.html
@@ -46,8 +46,6 @@
             InputViewModel(
                 field = form("buildingName"),
                 label = LabelViewModel(messages("site.buildingName"))
-                    .asPageHeading(Medium)
-                    .withCssClass("govuk-!-margin-bottom-3")
             ).withWidth(Full)
         )
 
@@ -57,8 +55,6 @@
             InputViewModel(
                 field = form("buildingNumber"),
                 label = LabelViewModel(messages("site.buildingNumber"))
-                    .asPageHeading(Medium)
-                    .withCssClass("govuk-!-margin-bottom-3")
             ).withWidth(Full)
         )
 
@@ -66,8 +62,6 @@
             InputViewModel(
                 field = form("postcode"),
                 label = LabelViewModel(messages("site.postcode"))
-                    .asPageHeading(Medium)
-                    .withCssClass("govuk-!-margin-bottom-3")
             ).withWidth(Fixed10)
         )
 

--- a/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsAllowanceView.scala.html
+++ b/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsAllowanceView.scala.html
@@ -45,7 +45,6 @@
             </ul>
 
             <p class="govuk-body">@messages(s"structuresBuildingsAllowance.p5.$userType")</p>
-
         </div>
 
         @formHelper(action = routes.StructuresBuildingsAllowanceController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
@@ -53,20 +52,9 @@
             @govukRadios(
                 RadiosViewModel.yesNo(
                     field = form("value"),
-                    legend = LegendViewModel(HtmlContent(
-                        s"""
-                        <div>
-                            <label class="govuk-label govuk-label--m">
-                                ${messages(s"structuresBuildingsAllowance.subHeading.$userType")}
-                            </label>
-                            <div class="govuk-hint govuk-!-margin-bottom-0">
-                                ${messages(s"structuresBuildingsAllowance.hint")}
-                            </div>
-                        </div>
-                        """
-                    ))
-                    .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
-                )
+                    legend = LegendViewModel(messages(s"structuresBuildingsAllowance.subHeading.$userType"))
+                    .withCssClass("govuk-fieldset__legend--m")
+                ).withHint(HintViewModel(messages(s"structuresBuildingsAllowance.hint")))
             )
 
             @submitButton()

--- a/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsClaimedView.scala.html
+++ b/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsClaimedView.scala.html
@@ -16,6 +16,7 @@
 
 @import controllers.journeys.capitalallowances.structuresBuildingsAllowance.routes
 @import models.common.{BusinessId, TaxYear, UserType}
+@import viewmodels.LegendSize.Large
 @import views.html.components._
 
 @this(
@@ -23,8 +24,7 @@
         formHelper: FormWithCSRF,
         errorSummarySection: ErrorSummarySection,
         govukRadios: GovukRadios,
-        submitButton: SubmitButton,
-        heading: Heading
+        submitButton: SubmitButton
 )
 
 @(form: Form[_], mode: Mode, userType: UserType, taxYear: TaxYear, businessId: BusinessId)(implicit request: Request[_], messages: Messages)
@@ -33,14 +33,14 @@
 
     @errorSummarySection(form, errorLinkOverrides = Map("value" -> "value_0"))
 
-    @heading(s"structuresBuildingsClaimed.subHeading.$userType") <br>
-
     @formHelper(action = routes.StructuresBuildingsClaimedController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
         @govukRadios(
-            RadiosViewModel.yesNo(
+             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(""))
+                legend = LegendViewModel(messages(s"structuresBuildingsClaimed.subHeading.$userType"))
+                .asPageHeading(Large)
+            )
         )
 
         @submitButton()

--- a/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsEligibleClaimView.scala.html
+++ b/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsEligibleClaimView.scala.html
@@ -38,38 +38,26 @@
         <ul class="govuk-list govuk-list--bullet">
             <li>@messages(s"structuresBuildingsEligibleClaim.l1.$userType")</li>
             <li>@messages("structuresBuildingsEligibleClaim.l2")
-        <a class="govuk-link" target="_blank" href=@messages("structuresBuildingsEligibleClaim.l2.href") >@messages("structuresBuildingsEligibleClaim.l2.link")</a>
+                <a class="govuk-link" target="_blank" href=@messages("structuresBuildingsEligibleClaim.l2.href") >@messages("structuresBuildingsEligibleClaim.l2.link")</a>
             </li>
             <li>@messages("structuresBuildingsEligibleClaim.l3")
-        <a class="govuk-link" target="_blank" href=@messages("structuresBuildingsEligibleClaim.l3.href") >@messages("structuresBuildingsEligibleClaim.l3.link")</a>
+                <a class="govuk-link" target="_blank" href=@messages("structuresBuildingsEligibleClaim.l3.href") >@messages("structuresBuildingsEligibleClaim.l3.link")</a>
             </li>
         </ul>
 
-        <a class="govuk-link" target="_blank" href=@messages("structuresBuildingsEligibleClaim.href") >@messages("structuresBuildingsEligibleClaim.link")</a>
-            <br><br>
+        <p class="govuk-body"><a class="govuk-link" target="_blank" href=@messages("structuresBuildingsEligibleClaim.href") >@messages("structuresBuildingsEligibleClaim.link")</a></p>
+    </div>
 
     @formHelper(action = routes.StructuresBuildingsEligibleClaimController.onSubmit(taxYear, businessId), Symbol("autoComplete") -> "off") {
 
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(HtmlContent(
-                    s"""
-                        <div>
-                            <label class="govuk-label govuk-label--m">
-                                ${messages(s"structuresBuildingsEligibleClaim.subHeading.$userType")}
-                            </label>
-                            <div class="govuk-hint govuk-!-margin-bottom-0">
-                                ${messages(s"structuresBuildingsEligibleClaim.hint.$userType")}
-                            </div>
-                        </div>
-                        """
-                )
-            )
-            )
-        )
+                legend = LegendViewModel(messages(s"structuresBuildingsEligibleClaim.subHeading.$userType"))
+                .withCssClass("govuk-fieldset__legend--m")
+            ).withHint(HintViewModel(messages(s"structuresBuildingsEligibleClaim.hint.$userType")))
+         )
 
         @submitButton()
-    </div>
     }
 }

--- a/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsLocationView.scala.html
+++ b/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsLocationView.scala.html
@@ -46,8 +46,6 @@
             InputViewModel(
                 field = form("buildingName"),
                 label = LabelViewModel(messages("site.buildingName"))
-                .asPageHeading(Medium)
-                .withCssClass("govuk-!-margin-bottom-3")
             ).withWidth(Full)
         )
 
@@ -57,8 +55,6 @@
             InputViewModel(
                 field = form("buildingNumber"),
                 label = LabelViewModel(messages("site.buildingNumber"))
-                .asPageHeading(Medium)
-                .withCssClass("govuk-!-margin-bottom-3")
             ).withWidth(Full)
         )
 
@@ -66,8 +62,6 @@
             InputViewModel(
                 field = form("postcode"),
                 label = LabelViewModel(messages("site.postcode"))
-                .asPageHeading(Medium)
-                .withCssClass("govuk-!-margin-bottom-3")
             ).withWidth(Fixed10)
         )
 

--- a/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsPreviousClaimUseView.scala.html
+++ b/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsPreviousClaimUseView.scala.html
@@ -45,29 +45,19 @@
             @messages(s"structuresBuildingsPreviousClaimUse.p4")
         </p>
         <a class="govuk-link" target="_blank" href=@messages("structuresBuildingsPreviousClaimUse.href") >@messages("structuresBuildingsPreviousClaimUse.link")</a>
+    </div>
 
     @formHelper(action = routes.StructuresBuildingsPreviousClaimUseController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(HtmlContent(
-                    s"""
-                        <div>
-                            <label class="govuk-label govuk-label--m">
-                                ${messages(s"structuresBuildingsPreviousClaimUse.subHeading.$userType")}
-                            </label>
-                            <div class="govuk-hint govuk-!-margin-bottom-0">
-                                ${messages(s"structuresBuildingsPreviousClaimUse.hint.$userType")}
-                            </div>
-                        </div>
-                        """
-                )
-            )
-            )
+                legend = LegendViewModel(messages(s"structuresBuildingsPreviousClaimUse.subHeading.$userType"))
+                .withCssClass("govuk-fieldset__legend--m")
+            ).withHint(HintViewModel(messages(s"structuresBuildingsPreviousClaimUse.hint.$userType")))
         )
 
         @submitButton()
-    </div>
+    
     }
 }

--- a/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsQualifyingUseDateView.scala.html
+++ b/app/views/journeys/capitalallowances/structuresBuildingsAllowance/StructuresBuildingsQualifyingUseDateView.scala.html
@@ -16,7 +16,6 @@
 
 @import controllers.journeys.capitalallowances.structuresBuildingsAllowance.routes
 @import models.common.{BusinessId, TaxYear, UserType}
-@import viewmodels.LegendSize.Medium
 @import views.html.components._
 
 @this(layout: templates.Layout,
@@ -43,7 +42,8 @@
         @govukDateInput(
             DateViewModel(
                 field  = form("structuresBuildingsQualifyingUseDate"),
-                legend = LegendViewModel(messages("structuresBuildingsQualifyingUseDate.subHeading")).asPageHeading(Medium)
+                legend = LegendViewModel(messages("structuresBuildingsQualifyingUseDate.subHeading"))
+                .withCssClass("govuk-fieldset__legend--m")
             )
             .withHint(HintViewModel(messages(s"structuresBuildingsQualifyingUseDate.hint.$userType")))
         )

--- a/app/views/journeys/capitalallowances/tailoring/ClaimCapitalAllowancesView.scala.html
+++ b/app/views/journeys/capitalallowances/tailoring/ClaimCapitalAllowancesView.scala.html
@@ -65,7 +65,7 @@
             RadiosViewModel.yesNo(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"claimCapitalAllowances.subHeading.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                .withCssClass("govuk-fieldset__legend--m")
             )
         )
 

--- a/app/views/journeys/capitalallowances/writingDownAllowance/WdaMainRateView.scala.html
+++ b/app/views/journeys/capitalallowances/writingDownAllowance/WdaMainRateView.scala.html
@@ -37,10 +37,11 @@
             <li>@messages("wdaMainRate.l1")</li>
             <li>@messages(s"wdaMainRate.l2.$userType")</li>
         </ul>
-
-        @formHelper(action = routes.WdaMainRateController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
-            @twoRadios(form, "wdaMainRate", userType, taxYear)
-            @submitButton()
-        }
     </div>
+
+    @formHelper(action = routes.WdaMainRateController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
+        @twoRadios(form, "wdaMainRate", userType, taxYear)
+        @submitButton()
+    }
+
 }

--- a/app/views/journeys/capitalallowances/zeroEmissionCars/ZecHowMuchDoYouWantToClaimView.scala.html
+++ b/app/views/journeys/capitalallowances/zeroEmissionCars/ZecHowMuchDoYouWantToClaimView.scala.html
@@ -66,7 +66,7 @@
             <div class="govuk-form-group @{ if (missingRadioError) "govuk-form-group--error" else "" }">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                        <h3 class="govuk-fieldset__heading">@messages(s"zecHowMuchDoYouWantToClaim.subHeading.$userType")</h3>
+                        @messages(s"zecHowMuchDoYouWantToClaim.subHeading.$userType")
                     </legend>
                     <div class="govuk-hint">@{messages("capitalAllowance.p3")}</div>
 

--- a/app/views/journeys/capitalallowances/zeroEmissionCars/ZeroEmissionCarsView.scala.html
+++ b/app/views/journeys/capitalallowances/zeroEmissionCars/ZeroEmissionCarsView.scala.html
@@ -60,21 +60,11 @@
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(HtmlContent(
-                        s"""
-                        <div>
-                            <label class="govuk-label govuk-label--m">
-                                ${messages(s"zecUsedForWork.subHeading.$userType", taxYear.startYear.toString, taxYear.endYear.toString)}
-                            </label>
-                            <div class="govuk-hint govuk-!-margin-bottom-0">
-                                ${messages(s"zecUsedForWork.hint.$userType")}
-                            </div>
-                        </div>
-                        """
-                ))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                legend = LegendViewModel(messages(s"zecUsedForWork.subHeading.$userType", taxYear.startYear.toString, taxYear.endYear.toString))
+                .withCssClass("govuk-fieldset__legend--m")
+            ).withHint(HintViewModel(messages(s"zecUsedForWork.hint.$userType")))
         )
-    )
+
 
         @submitButton()
     }

--- a/app/views/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZegvAllowanceView.scala.html
+++ b/app/views/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZegvAllowanceView.scala.html
@@ -58,7 +58,7 @@
             RadiosViewModel.yesNo(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"zeroEmission.subHeading.$userType"))
-                .withCssClass("govuk-fieldset__legend--m govuk-!-margin-bottom-5"),
+                .withCssClass("govuk-fieldset__legend--m"),
             )
         )
 

--- a/app/views/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZegvHowMuchDoYouWantToClaimView.scala.html
+++ b/app/views/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZegvHowMuchDoYouWantToClaimView.scala.html
@@ -77,7 +77,7 @@
         }">
             <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                    <h3 class="govuk-fieldset__heading">@messages(s"zegvHowMuchDoYouWantToClaim.subHeading.$userType")</h3>
+                    @messages(s"zegvHowMuchDoYouWantToClaim.subHeading.$userType")
                 </legend>
 
                 @missingRadioErrorMsg

--- a/app/views/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZeroEmissionGoodsVehiclesView.scala.html
+++ b/app/views/journeys/capitalallowances/zeroEmissionGoodsVehicle/ZeroEmissionGoodsVehiclesView.scala.html
@@ -68,7 +68,7 @@
             RadiosViewModel.yesNo(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"zeroEmissionGoodsVehicle.subHeading.$userType", taxYear.startYear.toString, taxYear.endYear.toString))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                .withCssClass("govuk-fieldset__legend--m")
         )
     )
 

--- a/app/views/journeys/expenses/advertisingOrMarketing/AdvertisingAmountView.scala.html
+++ b/app/views/journeys/expenses/advertisingOrMarketing/AdvertisingAmountView.scala.html
@@ -25,7 +25,8 @@
     formHelper: FormWithCSRF,
     errorSummarySection: ErrorSummarySection,
     govukInput: GovukInput,
-    submitButton: SubmitButton
+    submitButton: SubmitButton,
+    heading: Heading
 )
 
 @(form: Form[_], mode: Mode, userType: UserType, taxYear: TaxYear, businessId: BusinessId)(implicit request: Request[_], messages: Messages)
@@ -34,39 +35,37 @@
 
     @errorSummarySection(form)
 
+    @heading(s"advertisingAmount.title.$userType")
+
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+         <span class="govuk-details__summary-text">
+           ${messages("advertisingAmount.d1.heading")}
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+            <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>${messages("advertisingOrMarketing.l1")}</li>
+                <li>${messages("advertisingOrMarketing.l2")}</li>
+                <li>${messages("advertisingOrMarketing.l3")}</li>
+                <li>${messages("advertisingOrMarketing.l4")}</li>
+            </ul>
+            <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>${messages("entertainmentCosts.l1")}</li>
+                <li>${messages("entertainmentCosts.l2")}</li>
+            </ul>
+        </div>
+    </details>
+
     @formHelper(action = routes.AdvertisingAmountController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(HtmlContent(
-                    s"""
-                    <h1 class="govuk-label-wrapper">
-                        <label class="govuk-label govuk-label--l"> ${messages(s"advertisingAmount.title.$userType")} </label>
-                    </h1>
-                    <details class="govuk-details" data-module="govuk-details">
-                        <summary class="govuk-details__summary">
-                         <span class="govuk-details__summary-text">
-                           ${messages("advertisingAmount.d1.heading")}
-                          </span>
-                        </summary>
-                        <div class="govuk-details__text">
-                            <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
-                            <ul class="govuk-list govuk-list--bullet">
-                                <li>${messages("advertisingOrMarketing.l1")}</li>
-                                <li>${messages("advertisingOrMarketing.l2")}</li>
-                                <li>${messages("advertisingOrMarketing.l3")}</li>
-                                <li>${messages("advertisingOrMarketing.l4")}</li>
-                            </ul>
-                            <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
-                            <ul class="govuk-list govuk-list--bullet">
-                                <li>${messages("entertainmentCosts.l1")}</li>
-                                <li>${messages("entertainmentCosts.l2")}</li>
-                            </ul>
-                        </div>
-                    </details>
-                    """
-                ))
+                label = LabelViewModel(messages(s"advertisingAmount.title.$userType"))
+                .withCssClass("govuk-visually-hidden")
             )
             .asNumeric()
             .withHint(HintViewModel(messages("site.hint.amount")))

--- a/app/views/journeys/expenses/construction/ConstructionIndustryAmountView.scala.html
+++ b/app/views/journeys/expenses/construction/ConstructionIndustryAmountView.scala.html
@@ -24,7 +24,8 @@
         formHelper: FormWithCSRF,
         errorSummarySection: ErrorSummarySection,
         govukInput: GovukInput,
-        submitButton: SubmitButton
+        submitButton: SubmitButton,
+        heading: Heading
 )
 
 @(form: Form[_], mode: Mode, userType: UserType, taxYear: TaxYear, businessId: BusinessId)(implicit request: Request[_], messages: Messages)
@@ -33,27 +34,25 @@
 
         @errorSummarySection(form)
 
+        @heading(s"constructionIndustryAmount.heading.$userType")
+
+        <details class="govuk-details" data-module="govuk-details">
+           <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                    ${messages(s"expenses.understanding.construction")} </span>
+            </summary>
+            <div class="govuk-details__text">
+                <p class="govuk-body">${messages(s"expenses.includes.construction.$userType")}</p>
+            </div>
+        </details>
+
         @formHelper(action = routes.ConstructionIndustryAmountController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
             @govukInput(
                 InputViewModel(
                     field = form("value"),
-                    label = LabelViewModel(HtmlContent(
-                        s"""
-                    <h1 class="govuk-label-wrapper">
-                        <label class="govuk-label govuk-label--l"> ${messages(s"constructionIndustryAmount.heading.$userType")} </label>
-                    </h1>
-                    <details class="govuk-details" data-module="govuk-details">
-                       <summary class="govuk-details__summary">
-                            <span class="govuk-details__summary-text">
-                                ${messages(s"expenses.understanding.construction")} </span>
-                        </summary>
-                        <div class="govuk-details__text">
-                            <p class="govuk-body">${messages(s"expenses.includes.construction.$userType")}</p>
-                        </div>
-                    </details>
-                """
-                    ))
+                    label = LabelViewModel(messages(s"constructionIndustryAmount.heading.$userType"))
+                    .withCssClass("govuk-visually-hidden")
                 )
                 .asNumeric()
                 .withHint(HintViewModel(messages("site.hint.large.amount")))

--- a/app/views/journeys/expenses/depreciation/DepreciationDisallowableAmountView.scala.html
+++ b/app/views/journeys/expenses/depreciation/DepreciationDisallowableAmountView.scala.html
@@ -25,7 +25,8 @@
     formHelper: FormWithCSRF,
     errorSummarySection: ErrorSummarySection,
     govukInput: GovukInput,
-    submitButton: SubmitButton
+    submitButton: SubmitButton,
+    heading: Heading
 )
 
 @(form: Form[_], mode: Mode, userType: UserType, taxYear: TaxYear, businessId: BusinessId)(implicit request: Request[_], messages: Messages)
@@ -34,36 +35,30 @@
 
     @errorSummarySection(form)
 
+    @heading(s"depreciationDisallowableAmount.title.$userType")
+
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+                ${messages("depreciationDisallowableAmount.d1.heading")}
+            </span>
+        </summary>
+        <div class="govuk-details__text">
+            <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>${messages("depreciation.l1")}</li>
+                <li>${messages("depreciation.l2")}</li>
+            </ul>
+        </div>
+    </details>
+
     @formHelper(action = routes.DepreciationDisallowableAmountController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(HtmlContent(
-                        s"""
-                        <div>
-                            <h1 class="govuk-label-wrapper">
-                                <label class="govuk-label govuk-label--l">
-                                    ${messages(s"depreciationDisallowableAmount.title.$userType")}
-                                </label>
-                            </h1>
-                            <details class="govuk-details" data-module="govuk-details">
-                                <summary class="govuk-details__summary">
-                                    <span class="govuk-details__summary-text">
-                                        ${messages("depreciationDisallowableAmount.d1.heading")}
-                                    </span>
-                                </summary>
-                                <div class="govuk-details__text">
-                                    <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>${messages("depreciation.l1")}</li>
-                                        <li>${messages("depreciation.l2")}</li>
-                                    </ul>
-                                </div>
-                            </details>
-                        </div>
-                        """
-                        ))
+                label = LabelViewModel(messages(s"depreciationDisallowableAmount.title.$userType"))
+                .withCssClass("govuk-visually-hidden")
             )
             .asNumeric()
             .withHint(HintViewModel(messages("expenses.hint.disallowableExpenses")))

--- a/app/views/journeys/expenses/financialCharges/FinancialChargesAmountView.scala.html
+++ b/app/views/journeys/expenses/financialCharges/FinancialChargesAmountView.scala.html
@@ -20,11 +20,14 @@
 @import viewmodels.InputWidth._
 @import views.html.components._
 
-@this(layout: templates.Layout,
-      formHelper: FormWithCSRF,
-      errorSummarySection: ErrorSummarySection,
-      govukInput: GovukInput,
-      submitButton: SubmitButton)
+@this(
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        errorSummarySection: ErrorSummarySection,
+        govukInput: GovukInput,
+        submitButton: SubmitButton,
+        heading: Heading
+)
 
 @(form: Form[_],
   mode: Mode,
@@ -38,10 +41,33 @@
 
         @errorSummarySection(form)
 
+        @heading(s"financialChargesAmount.title.$userType")
+
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text"> @messages("financialExpenses.d2.heading")</span>
+            </summary>
+            <div class="govuk-details__text">
+                <p class="govuk-body">@messages(s"site.canInclude.$userType")</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>@messages("financialExpenses.d2.l1")</li>
+                    <li>@messages("financialExpenses.d2.l2")</li>
+                    <li>@messages("financialExpenses.d2.l3")</li>
+                    <li>@messages("financialExpenses.d2.l4")</li>
+                    <li>@messages("financialExpenses.d2.l5")</li>
+                </ul>
+                <p class="govuk-body">@messages(s"site.cannotInclude.$userType")</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>@messages("financialExpenses.d2.l6")</li>
+                </ul>
+            </div>
+        </details>
+
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(HtmlContent(buildLabelContent(userType)))
+                label = LabelViewModel(messages(s"financialChargesAmount.title.$userType"))
+                .withCssClass("govuk-visually-hidden")
             )
             .asNumeric()
             .withHint(HintViewModel(messages("site.hint.amount")))
@@ -53,27 +79,3 @@
     }
 }
 
-@buildLabelContent(user: UserType) = {
-    <h1 class="govuk-label-wrapper">
-        <label class="govuk-label govuk-label--l"> @messages(s"financialChargesAmount.title.$user") </label>
-    </h1>
-    <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text"> @messages("financialExpenses.d2.heading")</span>
-        </summary>
-        <div class="govuk-details__text">
-            <p class="govuk-body">@messages(s"site.canInclude.$user")</p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>@messages("financialExpenses.d2.l1")</li>
-                <li>@messages("financialExpenses.d2.l2")</li>
-                <li>@messages("financialExpenses.d2.l3")</li>
-                <li>@messages("financialExpenses.d2.l4")</li>
-                <li>@messages("financialExpenses.d2.l5")</li>
-            </ul>
-            <p class="govuk-body">@messages(s"site.cannotInclude.$user")</p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>@messages("financialExpenses.d2.l6")</li>
-            </ul>
-        </div>
-    </details>
-}

--- a/app/views/journeys/expenses/goodsToSellOrUse/GoodsToSellOrUseAmountView.scala.html
+++ b/app/views/journeys/expenses/goodsToSellOrUse/GoodsToSellOrUseAmountView.scala.html
@@ -25,7 +25,8 @@
     formHelper: FormWithCSRF,
     errorSummarySection: ErrorSummarySection,
     govukInput: GovukInput,
-    submitButton: SubmitButton
+    submitButton: SubmitButton,
+    heading: Heading
 )
 
 @(form: Form[_], mode: Mode, userType: UserType, taxYear: TaxYear, businessId: BusinessId, accountingType: AccountingType, taxiDriver: Boolean)(implicit request: Request[_], messages: Messages)
@@ -34,42 +35,40 @@
 
     @errorSummarySection(form)
 
+    @heading(s"goodsToSellOrUseAmount.title.$userType")
+
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+         <span class="govuk-details__summary-text">
+           ${messages("goodsToSellOrUseAmount.d1.heading")}
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+            <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
+            <ul class="govuk-list govuk-list--bullet">
+                ${if (taxiDriver) <li>{messages("expenses.fuelCosts")}</li> else ""}
+                <li>${messages("expenses.costOfRawMaterials")}</li>
+                ${if (accountingType == AccountingType.Cash) <li>{messages("expenses.stockBought")}</li> else ""}
+                <li>${messages("expenses.directCostsOfProducing")}</li>
+                ${if (accountingType == AccountingType.Accrual) <li>{messages("expenses.adjustments")}</li> else ""}
+                <li>${messages("expenses.commissions")}</li>
+                <li>${messages("expenses.discounts")}</li>
+            </ul>
+            <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
+            <ul class="govuk-list govuk-list--bullet">
+                ${if (accountingType == AccountingType.Cash) <li>{messages("expenses.costsForPrivateUse")}</li> else ""}
+                <li>${messages("expenses.depreciationOfEquipment")}</li>
+            </ul>
+        </div>
+    </details>
+
     @formHelper(action = routes.GoodsToSellOrUseAmountController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(HtmlContent(
-                    s"""
-                    <h1 class="govuk-label-wrapper">
-                        <label class="govuk-label govuk-label--l"> ${messages(s"goodsToSellOrUseAmount.title.$userType")} </label>
-                    </h1>
-                    <details class="govuk-details" data-module="govuk-details">
-                        <summary class="govuk-details__summary">
-                         <span class="govuk-details__summary-text">
-                           ${messages("goodsToSellOrUseAmount.d1.heading")}
-                          </span>
-                        </summary>
-                        <div class="govuk-details__text">
-                            <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
-                            <ul class="govuk-list govuk-list--bullet">
-                                ${if (taxiDriver) <li>{messages("expenses.fuelCosts")}</li> else ""}
-                                <li>${messages("expenses.costOfRawMaterials")}</li>
-                                ${if (accountingType == AccountingType.Cash) <li>{messages("expenses.stockBought")}</li> else ""}
-                                <li>${messages("expenses.directCostsOfProducing")}</li>
-                                ${if (accountingType == AccountingType.Accrual) <li>{messages("expenses.adjustments")}</li> else ""}
-                                <li>${messages("expenses.commissions")}</li>
-                                <li>${messages("expenses.discounts")}</li>
-                            </ul>
-                            <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
-                            <ul class="govuk-list govuk-list--bullet">
-                                ${if (accountingType == AccountingType.Cash) <li>{messages("expenses.costsForPrivateUse")}</li> else ""}
-                                <li>${messages("expenses.depreciationOfEquipment")}</li>
-                            </ul>
-                        </div>
-                    </details>
-                    """
-                ))
+                label = LabelViewModel(messages(s"goodsToSellOrUseAmount.title.$userType"))
+                .withCssClass("govuk-visually-hidden")
             )
             .asNumeric()
             .withHint(HintViewModel(messages("site.hint.amount")))

--- a/app/views/journeys/expenses/interest/InterestAmountView.scala.html
+++ b/app/views/journeys/expenses/interest/InterestAmountView.scala.html
@@ -24,7 +24,8 @@
         formHelper: FormWithCSRF,
         errorSummarySection: ErrorSummarySection,
         govukInput: GovukInput,
-        submitButton: SubmitButton
+        submitButton: SubmitButton,
+        heading: Heading
 )
 
 @(form: Form[_], mode: Mode, userType: UserType, taxYear: TaxYear, businessId: BusinessId, accountingType: AccountingType)(implicit request: Request[_], messages: Messages)
@@ -33,37 +34,35 @@
 
         @errorSummarySection(form)
 
+        @heading(s"interestAmount.title.$userType")
+
+        <details class="govuk-details" data-module="govuk-details">
+           <summary class="govuk-details__summary">
+               <span class="govuk-details__summary-text">
+                   ${messages("expenses.understanding.interest")} </span>
+           </summary>
+           <div class="govuk-details__text">
+               <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
+               <ul class="govuk-list govuk-list--bullet">
+                   <li>${messages(s"expenses.interest.${accountingType.entryName}")}</li>
+                   <li>${messages("expenses.feesForBuyingGoods")}</li>
+                   <li>${messages("expenses.hirePurchase")}</li>
+               </ul>
+               <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
+               <ul class="govuk-list govuk-list--bullet">
+                   <li>${messages("expenses.repaymentsOfLoans")}</li>
+                   <li>${messages("expenses.overdraftOrFinancialArrangements")}</li>
+               </ul>
+           </div>
+        </details>
+
         @formHelper(action = routes.InterestAmountController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
             @govukInput(
                 InputViewModel(
                     field = form("value"),
-                    label = LabelViewModel(HtmlContent(
-                        s"""
-                <h1 class="govuk-label-wrapper">
-                    <label class="govuk-label govuk-label--l"> ${messages(s"interestAmount.title.$userType")} </label>
-                </h1>
-                   <details class="govuk-details" data-module="govuk-details">
-                       <summary class="govuk-details__summary">
-                           <span class="govuk-details__summary-text">
-                               ${messages("expenses.understanding.interest")} </span>
-                       </summary>
-                       <div class="govuk-details__text">
-                           <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
-                           <ul class="govuk-list govuk-list--bullet">
-                               <li>${messages(s"expenses.interest.${accountingType.entryName}")}</li>
-                               <li>${messages("expenses.feesForBuyingGoods")}</li>
-                               <li>${messages("expenses.hirePurchase")}</li>
-                           </ul>
-                           <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
-                           <ul class="govuk-list govuk-list--bullet">
-                               <li>${messages("expenses.repaymentsOfLoans")}</li>
-                               <li>${messages("expenses.overdraftOrFinancialArrangements")}</li>
-                           </ul>
-                       </div>
-                    </details>
-                """
-                    ))
+                    label = LabelViewModel(messages(s"interestAmount.title.$userType"))
+                    .withCssClass("govuk-visually-hidden")
                 )
                 .asNumeric()
                 .withHint(HintViewModel(messages("site.hint.amount")))

--- a/app/views/journeys/expenses/irrecoverableDebts/IrrecoverableDebtsAmountView.scala.html
+++ b/app/views/journeys/expenses/irrecoverableDebts/IrrecoverableDebtsAmountView.scala.html
@@ -24,7 +24,8 @@
         formHelper: FormWithCSRF,
         errorSummarySection: ErrorSummarySection,
         govukInput: GovukInput,
-        submitButton: SubmitButton
+        submitButton: SubmitButton,
+        heading: Heading
 )
 
 @(form: Form[_], mode: Mode, userType: UserType, taxYear: TaxYear, businessId: BusinessId)(implicit request: Request[_], messages: Messages)
@@ -33,13 +34,33 @@
 
     @errorSummarySection(form)
 
+    @heading(s"irrecoverableDebtsAmount.title.$userType")
+
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text"> @messages("financialExpenses.d3.heading")</span>
+        </summary>
+        <div class="govuk-details__text">
+            <p class="govuk-body">@messages(s"site.canInclude.$userType")</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>@messages("financialExpenses.d3.l1")</li>
+            </ul>
+            <p class="govuk-body">@messages(s"site.cannotInclude.$userType")</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>@messages("expenses.debtsNotIncludedInTurnover")</li>
+                <li>@messages("expenses.debtsRelatingToFixedAssets")</li>
+                <li>@messages("expenses.generalBadDebts")</li>
+            </ul>
+        </div>
+    </details>
+
     @formHelper(action = routes.IrrecoverableDebtsAmountController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(HtmlContent(buildLabelContent(userType)))
-            )
+                label = LabelViewModel(messages(s"irrecoverableDebtsAmount.title.$userType"))
+                .withCssClass("govuk-visually-hidden")            )
             .asNumeric()
             .withHint(HintViewModel(messages("site.hint.amount")))
             .withWidth(Fixed10)
@@ -50,25 +71,3 @@
     }
 }
 
-@buildLabelContent(user: UserType) = {
-    <h1 class="govuk-label-wrapper">
-        <label class="govuk-label govuk-label--l"> @messages(s"irrecoverableDebtsAmount.title.$user") </label>
-    </h1>
-    <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text"> @messages("financialExpenses.d3.heading")</span>
-        </summary>
-        <div class="govuk-details__text">
-            <p class="govuk-body">@messages(s"site.canInclude.$user")</p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>@messages("financialExpenses.d3.l1")</li>
-            </ul>
-            <p class="govuk-body">@messages(s"site.cannotInclude.$user")</p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>@messages("expenses.debtsNotIncludedInTurnover")</li>
-                <li>@messages("expenses.debtsRelatingToFixedAssets")</li>
-                <li>@messages("expenses.generalBadDebts")</li>
-            </ul>
-        </div>
-    </details>
-}

--- a/app/views/journeys/expenses/officeSupplies/OfficeSuppliesAmountView.scala.html
+++ b/app/views/journeys/expenses/officeSupplies/OfficeSuppliesAmountView.scala.html
@@ -20,11 +20,14 @@
 @import viewmodels.InputWidth._
 @import views.html.components._
 
-@this(layout: templates.Layout,
+@this(
+      layout: templates.Layout,
       formHelper: FormWithCSRF,
       errorSummarySection: ErrorSummarySection,
       govukInput: GovukInput,
-      submitButton: SubmitButton)
+      submitButton: SubmitButton,
+      heading: Heading
+)
 
 @(form: Form[_], mode: Mode, userType: UserType, accountingType: AccountingType, taxYear: TaxYear, businessId: BusinessId)(implicit request: Request[_], messages: Messages)
 
@@ -34,10 +37,40 @@
 
         @errorSummarySection(form)
 
+        @heading(s"officeSuppliesAmount.title.$userType")
+
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text"> @messages("officeSuppliesAmount.understandingOfficeSuppliesExpenses") </span>
+            </summary>
+            <div class="govuk-details__text">
+                <p class="govuk-body">@messages(s"site.canInclude.$userType")</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>@messages("officeSupplies.l1")</li>
+                    <li>@messages("officeSupplies.l2")</li>
+                    <li>@messages("officeSupplies.l3")</li>
+                    <li>@messages("officeSupplies.l4")</li>
+                    <li>@messages("officeSupplies.l5")</li>
+                    @if(accountingType == AccountingType.Cash) {
+                        <li>@messages("officeSupplies.l6")</li>
+                    }
+                </ul>
+                <p class="govuk-body">@messages(s"site.cannotInclude.$userType")</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    @if(accountingType == AccountingType.Cash) {
+                        <li>@messages("expenses.listItem.anyAmount")</li>
+                    } else {
+                        <li>@messages("officeSupplies.l7")</li>
+                    }
+                </ul>
+            </div>
+        </details>
+
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(HtmlContent(buildLabelContent(userType, accountingType)))
+                label = LabelViewModel(messages(s"officeSuppliesAmount.title.$userType"))
+                .withCssClass("govuk-visually-hidden")
             )
             .asNumeric()
             .withHint(HintViewModel(messages("site.hint.amount")))
@@ -49,34 +82,3 @@
     }
 }
 
-@buildLabelContent(userType: UserType, accountingType: AccountingType) = {
-    <h1 class="govuk-label-wrapper">
-        <label class="govuk-label govuk-label--l"> @messages(s"officeSuppliesAmount.title.$userType") </label>
-    </h1>
-    <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text"> @messages("officeSuppliesAmount.understandingOfficeSuppliesExpenses") </span>
-        </summary>
-        <div class="govuk-details__text">
-            <p class="govuk-body">@messages(s"site.canInclude.$userType")</p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>@messages("officeSupplies.l1")</li>
-                <li>@messages("officeSupplies.l2")</li>
-                <li>@messages("officeSupplies.l3")</li>
-                <li>@messages("officeSupplies.l4")</li>
-                <li>@messages("officeSupplies.l5")</li>
-                @if(accountingType == AccountingType.Cash) {
-                    <li>@messages("officeSupplies.l6")</li>
-                }
-            </ul>
-            <p class="govuk-body">@messages(s"site.cannotInclude.$userType")</p>
-            <ul class="govuk-list govuk-list--bullet">
-                @if(accountingType == AccountingType.Cash) {
-                    <li>@messages("expenses.listItem.anyAmount")</li>
-                } else {
-                    <li>@messages("officeSupplies.l7")</li>
-                }
-            </ul>
-        </div>
-    </details>
-}

--- a/app/views/journeys/expenses/otherExpenses/OtherExpensesAmountView.scala.html
+++ b/app/views/journeys/expenses/otherExpenses/OtherExpensesAmountView.scala.html
@@ -22,11 +22,14 @@
 @import viewmodels.InputWidth._
 @import views.html.components._
 
-@this(layout: templates.Layout,
+@this(
+    layout: templates.Layout,
     formHelper: FormWithCSRF,
     errorSummarySection: ErrorSummarySection,
     govukInput: GovukInput,
-    submitButton: SubmitButton)
+    submitButton: SubmitButton,
+    heading: Heading
+)
 
 @(form: Form[_],
   mode: Mode,
@@ -42,10 +45,37 @@
 
         @errorSummarySection(form)
 
+        @heading(s"otherExpensesAmount.title.$userType")
+
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text"> @messages("otherExpensesAmount.understandingOtherExpenses")</span>
+            </summary>
+            <div class="govuk-details__text">
+                <p class="govuk-body">@messages(s"site.canInclude.$userType")</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>@messages("otherExpenses.l1")</li>
+                    <li>@messages("otherExpenses.l2")</li>
+                </ul>
+                @tailoringAnswer match {
+                    case YesAllowable => {
+                        <p class="govuk-body">@messages(s"site.cannotInclude.$userType")</p>
+                        <ul class="govuk-list govuk-list--bullet">
+                            <li>@messages("otherExpenses.l3")</li>
+                            <li>@messages("otherExpenses.l4")</li>
+                            <li>@messages("otherExpenses.l5")</li>
+                        </ul>
+                    }
+                    case _ => {}
+                }
+            </div>
+        </details>
+
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(HtmlContent(buildLabelContent(userType, tailoringAnswer)))
+                label = LabelViewModel(messages(s"otherExpensesAmount.title.$userType"))
+                .withCssClass("govuk-visually-hidden")
             )
             .asNumeric()
             .withHint(HintViewModel(messages("site.hint.amount")))
@@ -55,33 +85,4 @@
 
         @submitButton()
     }
-}
-
-@buildLabelContent(user: UserType, tailoringAnswer: OtherExpenses) = {
-    <h1 class="govuk-label-wrapper">
-        <label class="govuk-label govuk-label--l"> @messages(s"otherExpensesAmount.title.$user") </label>
-    </h1>
-    <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text"> @messages("otherExpensesAmount.understandingOtherExpenses")</span>
-        </summary>
-        <div class="govuk-details__text">
-            <p class="govuk-body">@messages(s"site.canInclude.$user")</p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>@messages("otherExpenses.l1")</li>
-                <li>@messages("otherExpenses.l2")</li>
-            </ul>
-            @tailoringAnswer match {
-                case YesAllowable => {
-                    <p class="govuk-body">@messages(s"site.cannotInclude.$user")</p>
-                    <ul class="govuk-list govuk-list--bullet">
-                        <li>@messages("otherExpenses.l3")</li>
-                        <li>@messages("otherExpenses.l4")</li>
-                        <li>@messages("otherExpenses.l5")</li>
-                    </ul>
-                }
-                case _ => {}
-            }
-        </div>
-    </details>
 }

--- a/app/views/journeys/expenses/professionalFees/ProfessionalFeesAmountView.scala.html
+++ b/app/views/journeys/expenses/professionalFees/ProfessionalFeesAmountView.scala.html
@@ -25,7 +25,8 @@
         formHelper: FormWithCSRF,
         errorSummarySection: ErrorSummarySection,
         govukInput: GovukInput,
-        submitButton: SubmitButton
+        submitButton: SubmitButton,
+        heading: Heading
 )
 
 @(form: Form[_], mode: Mode, userType: UserType, taxYear: TaxYear, businessId: BusinessId, accountingType: AccountingType)(implicit request: Request[_], messages: Messages)
@@ -34,43 +35,42 @@
 
         @errorSummarySection(form)
 
+
+        @heading(s"professionalFeesAmount.title.$userType")
+
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">${messages("professionalServiceExpenses.d3.heading")}</span>
+            </summary>
+            <div class="govuk-details__text">
+                <p class="govuk-body">${messages(s"site.canIncludeFees.$userType")}</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>${messages("professionalServiceExpenses.d3.l1")}</li>
+                    <li>${messages("professionalServiceExpenses.d3.l2")}</li>
+                    <li>${messages("professionalServiceExpenses.d3.l3")}</li>
+                    <li>${messages("professionalServiceExpenses.d3.l4")}</li>
+                    <li>${messages("professionalServiceExpenses.d3.l5")}</li>
+                </ul>
+                <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>${messages("expenses.legalCost.property")}</li>
+                    ${if(accountingType == Accrual) {
+                      <li>{messages("expenses.legalCost.equipment")}</li>
+                    } else { "" } }
+                    <li>${messages("expenses.taxDisputes")}</li>
+                    <li>${messages("expenses.fines")}</li>
+                </ul>
+            </div>
+        </details>
+
+
         @formHelper(action = routes.ProfessionalFeesAmountController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
             @govukInput(
                 InputViewModel(
                     field = form("value"),
-                    label = LabelViewModel(HtmlContent(
-                        s"""
-                <h1 class="govuk-label-wrapper">
-                    <label class="govuk-label govuk-label--l"> ${messages(s"professionalFeesAmount.title.$userType")} </label>
-                </h1>
-                   <details class="govuk-details" data-module="govuk-details">
-                       <summary class="govuk-details__summary">
-                           <span class="govuk-details__summary-text">
-                               ${messages("professionalServiceExpenses.d3.heading")} </span>
-                       </summary>
-                       <div class="govuk-details__text">
-                           <p class="govuk-body">${messages(s"site.canIncludeFees.$userType")}</p>
-                           <ul class="govuk-list govuk-list--bullet">
-                               <li>${messages("professionalServiceExpenses.d3.l1")}</li>
-                               <li>${messages("professionalServiceExpenses.d3.l2")}</li>
-                               <li>${messages("professionalServiceExpenses.d3.l3")}</li>
-                               <li>${messages("professionalServiceExpenses.d3.l4")}</li>
-                               <li>${messages("professionalServiceExpenses.d3.l5")}</li>
-                           </ul>
-                           <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
-                           <ul class="govuk-list govuk-list--bullet">
-                               <li>${messages("expenses.legalCost.property")}</li>
-                               ${if(accountingType == Accrual) {
-                                  <li>{messages("expenses.legalCost.equipment")}</li>
-                               } else { "" } }
-                               <li>${messages("expenses.taxDisputes")}</li>
-                               <li>${messages("expenses.fines")}</li>
-                           </ul>
-                       </div>
-                    </details>
-                """
-                    ))
+                    label = LabelViewModel(messages(s"professionalFeesAmount.title.$userType"))
+                    .withCssClass("govuk-visually-hidden")
                 )
                 .asNumeric()
                 .withHint(HintViewModel(messages("site.hint.amount")))

--- a/app/views/journeys/expenses/staffCosts/StaffCostsAmountView.scala.html
+++ b/app/views/journeys/expenses/staffCosts/StaffCostsAmountView.scala.html
@@ -25,7 +25,8 @@
     formHelper: FormWithCSRF,
     errorSummarySection: ErrorSummarySection,
     govukInput: GovukInput,
-    submitButton: SubmitButton
+    submitButton: SubmitButton,
+    heading: Heading
 )
 
 @(form: Form[_], mode: Mode, userType: UserType, taxYear: TaxYear, businessId: BusinessId, isDisallowable: Boolean
@@ -35,47 +36,45 @@
 
     @errorSummarySection(form)
 
+    @heading(s"staffCostsAmount.title.$userType")
+
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+                ${messages("staffCostsAmount.d1.heading")}
+            </span>
+        </summary>
+        <div class="govuk-details__text">
+            <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>${messages("expenses.salaries")}</li>
+                <li>${messages("expenses.wages")}</li>
+                <li>${messages("expenses.bonuses")}</li>
+                <li>${messages("expenses.pensions")}</li>
+                <li>${messages("expenses.benefitsForEmployees")}</li>
+                <li>${messages("expenses.agencyFees")}</li>
+                <li>${messages("expenses.subcontractLabourCosts")}</li>
+                <li>${messages("expenses.nationalInsuranceContributions")}</li>
+            </ul>
+            ${if (isDisallowable) {
+                s"""
+                <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>${messages(s"expenses.contributions.$userType")}</li>
+                    <li>${messages("staffCosts.personalUse")}</li>
+                </ul>
+                """
+            } else { "" } }
+        </div>
+    </details>
+
     @formHelper(action = routes.StaffCostsAmountController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(HtmlContent(
-                    s"""
-                    <h1 class="govuk-label-wrapper">
-                        <label class="govuk-label govuk-label--l"> ${messages(s"staffCostsAmount.title.$userType")} </label>
-                    </h1>
-                    <details class="govuk-details" data-module="govuk-details">
-                        <summary class="govuk-details__summary">
-                            <span class="govuk-details__summary-text">
-                                ${messages("staffCostsAmount.d1.heading")}
-                            </span>
-                        </summary>
-                        <div class="govuk-details__text">
-                            <p class="govuk-body">${messages(s"site.canInclude.$userType")}</p>
-                            <ul class="govuk-list govuk-list--bullet">
-                                <li>${messages("expenses.salaries")}</li>
-                                <li>${messages("expenses.wages")}</li>
-                                <li>${messages("expenses.bonuses")}</li>
-                                <li>${messages("expenses.pensions")}</li>
-                                <li>${messages("expenses.benefitsForEmployees")}</li>
-                                <li>${messages("expenses.agencyFees")}</li>
-                                <li>${messages("expenses.subcontractLabourCosts")}</li>
-                                <li>${messages("expenses.nationalInsuranceContributions")}</li>
-                            </ul>
-                            ${if (isDisallowable) {
-                                s"""
-                                <p class="govuk-body">${messages(s"site.cannotInclude.$userType")}</p>
-                                <ul class="govuk-list govuk-list--bullet">
-                                    <li>${messages(s"expenses.contributions.$userType")}</li>
-                                    <li>${messages("staffCosts.personalUse")}</li>
-                                </ul>
-                                """
-                            } else { "" } }
-                        </div>
-                    </details>
-                    """
-                ))
+                label = LabelViewModel(messages(s"staffCostsAmount.title.$userType"))
+                .withCssClass("govuk-visually-hidden")
             )
             .asNumeric()
             .withHint(HintViewModel(messages("site.hint.large.amount")))

--- a/app/views/journeys/expenses/tailoring/ExpensesCategoriesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/ExpensesCategoriesView.scala.html
@@ -26,6 +26,7 @@
     govukRadios: GovukRadios,
     submitButton: SubmitButton,
     heading: Heading,
+    heading2: Heading2,
     foldableDetails: FoldableDetails
 )
 
@@ -40,7 +41,7 @@
     <div class="govuk-form-group">
         <p class="govuk-body">@messages(s"expensesCategories.p1.$userType")</p>
         <p class="govuk-body">@messages(s"expensesCategories.p2.$userType")</p>
-        @heading("expensesCategories.subHeading", headerSize = "m")
+        @heading2("expensesCategories.subHeading")
         <p class="govuk-body">@messages("expensesCategories.p3")</p>
 
         @foldableDetails(messages("expensesCategories.details.heading"), "govuk-!-margin-bottom-3") {
@@ -68,7 +69,7 @@
             RadiosViewModel(
                 field  = form("value"),
                 legend = LegendViewModel(messages(s"expenses.cyaSummary.$userType"))
-                            .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m"),
+                .withCssClass("govuk-fieldset__legend--m"),
                 items  = ExpensesTailoring.options(userType)
             )
         )

--- a/app/views/journeys/expenses/tailoring/individualCategories/AdvertisingOrMarketingView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/AdvertisingOrMarketingView.scala.html
@@ -59,7 +59,7 @@
             RadiosViewModel(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"advertisingOrMarketing.question.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m"),
+                .withCssClass("govuk-fieldset__legend--m"),
                 items = AdvertisingOrMarketing.options(userType)
             )
         )

--- a/app/views/journeys/expenses/tailoring/individualCategories/DepreciationView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DepreciationView.scala.html
@@ -52,7 +52,7 @@
             RadiosViewModel.yesNoVertical(
                 field  = form("value"),
                 legend = LegendViewModel(messages(s"depreciation.subHeading.$userType"))
-                            .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                .withCssClass("govuk-fieldset__legend--m")
             )
         )
 

--- a/app/views/journeys/expenses/tailoring/individualCategories/DisallowableInterestView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DisallowableInterestView.scala.html
@@ -51,7 +51,7 @@
             RadiosViewModel.yesNoVertical(
                 field  = form("value"),
                 legend = LegendViewModel(messages(s"disallowableInterest.title.$userType"))
-                            .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                .withCssClass("govuk-fieldset__legend--m")
             )
         )
 

--- a/app/views/journeys/expenses/tailoring/individualCategories/DisallowableIrrecoverableDebtsView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DisallowableIrrecoverableDebtsView.scala.html
@@ -52,7 +52,7 @@
             RadiosViewModel.yesNoVertical(
                 field  = form("value"),
                 legend = LegendViewModel(messages(s"disallowableIrrecoverableDebts.title.$userType"))
-                            .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                .withCssClass("govuk-fieldset__legend--m")
             )
         )
 

--- a/app/views/journeys/expenses/tailoring/individualCategories/DisallowableOtherFinancialChargesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DisallowableOtherFinancialChargesView.scala.html
@@ -47,7 +47,7 @@
             RadiosViewModel.yesNoVertical(
                 field  = form("value"),
                 legend = LegendViewModel(messages(s"disallowableOtherFinancialCharges.title.$userType"))
-                            .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                .withCssClass("govuk-fieldset__legend--m")
             )
         )
 

--- a/app/views/journeys/expenses/tailoring/individualCategories/DisallowableProfessionalFeesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DisallowableProfessionalFeesView.scala.html
@@ -52,7 +52,7 @@
             RadiosViewModel.yesNoVertical(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"disallowableProfessionalFees.subHeading.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                .withCssClass("govuk-fieldset__legend--m")
             )
         )
 

--- a/app/views/journeys/expenses/tailoring/individualCategories/DisallowableStaffCostsView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DisallowableStaffCostsView.scala.html
@@ -53,9 +53,8 @@
         @govukRadios(
             RadiosViewModel.yesNoVertical(
                 field = form("value"),
-                legend = LegendViewModel(messages(
-                    s"disallowableStaffCosts.subHeading.$userType"))
-                                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                legend = LegendViewModel(messages(s"disallowableStaffCosts.subHeading.$userType"))
+                .withCssClass("govuk-fieldset__legend--m")
             )
         )
 

--- a/app/views/journeys/expenses/tailoring/individualCategories/DisallowableSubcontractorCostsView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/DisallowableSubcontractorCostsView.scala.html
@@ -46,7 +46,7 @@
             RadiosViewModel.yesNoVertical(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"disallowableSubcontractorCosts.subHeading.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                .withCssClass("govuk-fieldset__legend--m")
             )
         )
 

--- a/app/views/journeys/expenses/tailoring/individualCategories/EntertainmentCostsView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/EntertainmentCostsView.scala.html
@@ -52,7 +52,7 @@
             RadiosViewModel.yesNoVertical(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"entertainmentCosts.question.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                .withCssClass("govuk-fieldset__legend--m")
             )
         )
 

--- a/app/views/journeys/expenses/tailoring/individualCategories/FinancialExpensesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/FinancialExpensesView.scala.html
@@ -37,11 +37,11 @@
 
     @heading("financialExpenses.title")
 
-    <details class="govuk-details govuk-!-margin-bottom-3" data-module="govuk-details">
+    <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">
-                            <span class="govuk-details__summary-text">
-                                @messages("expenses.understanding.interest")
-                            </span>
+            <span class="govuk-details__summary-text">
+                @messages("expenses.understanding.interest")
+            </span>
         </summary>
         <div class="govuk-details__text">
             <p class="govuk-body">
@@ -62,11 +62,11 @@
         </div>
     </details>
 
-    <details class="govuk-details govuk-!-margin-bottom-3" data-module="govuk-details">
+    <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">
-                            <span class="govuk-details__summary-text">
-                                @messages("financialExpenses.d2.heading")
-                            </span>
+            <span class="govuk-details__summary-text">
+                @messages("financialExpenses.d2.heading")
+            </span>
         </summary>
         <div class="govuk-details__text">
             <p class="govuk-body">
@@ -91,9 +91,9 @@
     @if(accountingType == AccountingType.Accrual){
         <details class="govuk-details" data-module="govuk-details">
             <summary class="govuk-details__summary">
-                                <span class="govuk-details__summary-text">
-                                    @messages("financialExpenses.d3.heading")
-                                </span>
+                <span class="govuk-details__summary-text">
+                    @messages("financialExpenses.d3.heading")
+                </span>
             </summary>
             <div class="govuk-details__text">
                 <p class="govuk-body">
@@ -121,19 +121,9 @@
                 form   = form,
                 name   = "value",
                 items  = FinancialExpenses.checkboxItems(userType, accountingType),
-                legend = LegendViewModel(HtmlContent(
-                    s"""
-                    <div>
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                            ${messages(s"financialExpenses.subHeading.$userType")}
-                        </legend>
-                        <div class="govuk-hint">
-                            ${messages("site.selectAllThatApply")}
-                        </div>
-                    </div>
-                    """
-                )).withCssClass("no-margin-bottom")
-            )
+                legend = LegendViewModel(messages(s"financialExpenses.subHeading.$userType"))
+                .withCssClass("govuk-fieldset__legend--m")
+            ).withHint(Some(HintViewModel(messages("site.selectAllThatApply"))))
         )
 
         @submitButton()

--- a/app/views/journeys/expenses/tailoring/individualCategories/GoodsToSellOrUseView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/GoodsToSellOrUseView.scala.html
@@ -74,7 +74,7 @@
             RadiosViewModel(
                 field  = form("value"),
                 legend = LegendViewModel(messages(s"goodsToSellOrUse.question.$userType"))
-                            .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m"),
+                .withCssClass("govuk-fieldset__legend--m"),
                 items  = GoodsToSellOrUse.options(userType)
             )
         )

--- a/app/views/journeys/expenses/tailoring/individualCategories/OfficeSuppliesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/OfficeSuppliesView.scala.html
@@ -68,7 +68,7 @@
             RadiosViewModel(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"officeSupplies.question.$userType"))
-                             .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m"),
+                 .withCssClass("govuk-fieldset__legend--m"),
                 items = OfficeSupplies.options(userType)
             )
         )

--- a/app/views/journeys/expenses/tailoring/individualCategories/OtherExpensesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/OtherExpensesView.scala.html
@@ -60,7 +60,7 @@
             RadiosViewModel(
                 field  = form("value"),
                 legend = LegendViewModel(messages(s"otherExpenses.subHeading.$userType"))
-                            .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m"),
+                .withCssClass("govuk-fieldset__legend--m"),
                 items  = OtherExpenses.options(userType)
             )
         )

--- a/app/views/journeys/expenses/tailoring/individualCategories/ProfessionalServiceExpensesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/ProfessionalServiceExpensesView.scala.html
@@ -117,19 +117,9 @@
                 form = form,
                 name = "value",
                 items = ProfessionalServiceExpenses.checkboxItems(userType),
-                legend = LegendViewModel(HtmlContent(
-                    s"""
-                        <div>
-                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                                ${messages(s"professionalServiceExpenses.subHeading.$userType")}
-                            </legend>
-                            <div class="govuk-hint">
-                                ${messages("site.selectAllThatApply")}
-                            </div>
-                        </div>
-                    """
-                )).withCssClass("no-margin-bottom")
-            )
+                legend = LegendViewModel(messages(s"professionalServiceExpenses.subHeading.$userType"))
+                .withCssClass("govuk-fieldset__legend--m")
+            ).withHint(Some(HintViewModel(messages("site.selectAllThatApply"))))
         )
 
         @submitButton()

--- a/app/views/journeys/expenses/tailoring/individualCategories/RepairsAndMaintenanceView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/RepairsAndMaintenanceView.scala.html
@@ -64,7 +64,7 @@
             RadiosViewModel(
                 field  = form("value"),
                 legend = LegendViewModel(messages(s"repairsAndMaintenance.subHeading.$userType"))
-                            .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m"),
+                .withCssClass("govuk-fieldset__legend--m"),
                 items  = RepairsAndMaintenance.options(userType)
             )
         )

--- a/app/views/journeys/expenses/tailoring/individualCategories/TaxiMinicabOrRoadHaulageView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/TaxiMinicabOrRoadHaulageView.scala.html
@@ -16,6 +16,7 @@
 
 @import controllers.journeys.expenses.goodsToSellOrUse.routes
 @import models.common.{BusinessId, TaxYear, UserType}
+@import viewmodels.LegendSize.Large
 @import views.html.components._
 
 @this(
@@ -38,6 +39,7 @@
             RadiosViewModel.yesNoVertical(
                 field  = form("value"),
                 legend = LegendViewModel(messages(s"taxiMinicabOrRoadHaulage.title.$userType"))
+                .asPageHeading(size = Large)
                 .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--l")
             )
         )

--- a/app/views/journeys/expenses/tailoring/individualCategories/TravelForWorkView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/TravelForWorkView.scala.html
@@ -57,7 +57,7 @@
             RadiosViewModel(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"travelForWork.question.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m"),
+                .withCssClass("govuk-fieldset__legend--m"),
                 items = TravelForWork.options(userType)
             )
         )

--- a/app/views/journeys/expenses/tailoring/individualCategories/WorkFromBusinessPremisesView.scala.html
+++ b/app/views/journeys/expenses/tailoring/individualCategories/WorkFromBusinessPremisesView.scala.html
@@ -19,6 +19,7 @@
 @import models.journeys.expenses.individualCategories.WorkFromBusinessPremises
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 @import views.html.components._
+@import viewmodels.LegendSize.Large
 
 @this(
     layout: templates.Layout,
@@ -40,19 +41,8 @@
             RadiosViewModel(
                 field  = form("value"),
                 items  = WorkFromBusinessPremises.options(userType),
-                legend = LegendViewModel(HtmlContent(
-                    s"""
-                        <div>
-                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                                ${messages(s"workFromBusinessPremises.title.$userType")}
-                            </legend>
-                            <div class="govuk-hint">
-                                ${messages(s"workFromBusinessPremises.hint.$userType")}
-                            </div>
-                        </div>
-                    """
-                )).withCssClass("no-margin-bottom")
-            )
+                legend = LegendViewModel(messages(s"workFromBusinessPremises.title.$userType")).asPageHeading(Large)
+            ).withHint(HintViewModel(messages(s"workFromBusinessPremises.hint.$userType")))
         )
 
         @submitButton()

--- a/app/views/journeys/expenses/travelAndAccommodation/TravelAndAccommodationExpenseTypeView.scala.html
+++ b/app/views/journeys/expenses/travelAndAccommodation/TravelAndAccommodationExpenseTypeView.scala.html
@@ -37,16 +37,14 @@
 
     @formHelper(action = routes.TravelAndAccommodationExpenseTypeController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
-        <h1 class="govuk-heading-l">@messages(s"travelAndAccommodationExpenseType.title.$userType")</h1>
-        <div class="govuk-hint"> @messages(s"site.selectAllThatApply") </div>
-
         @govukCheckboxes(
             CheckboxesViewModel(
-                form   = form,
-                name   = "value",
-                legend = LegendViewModel("").asPageHeading(),
-                items  = TravelAndAccommodationExpenseType.checkboxItems(messages, userType)
-            )
+                form = form,
+                name = "value",
+                items  = TravelAndAccommodationExpenseType.checkboxItems(messages, userType),
+                legend = LegendViewModel(messages(s"travelAndAccommodationExpenseType.title.$userType"))
+                .asPageHeading(size = LegendSize.Large)
+            ).withHint(Some(HintViewModel(messages(s"site.selectAllThatApply"))))
         )
 
         @govukButton(

--- a/app/views/journeys/expenses/travelAndAccommodation/TravelForWorkYourMileageView.scala.html
+++ b/app/views/journeys/expenses/travelAndAccommodation/TravelForWorkYourMileageView.scala.html
@@ -50,7 +50,8 @@
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages(s"travelForWorkYourMileage.formLabel.$userType", vehicle)).asPageHeading(Medium)
+                label = LabelViewModel(messages(s"travelForWorkYourMileage.formLabel.$userType", vehicle))
+                .withCssClass("govuk-heading-m")
             )
             .asNumeric()
             .withWidth(Fixed10)

--- a/app/views/journeys/expenses/travelAndAccommodation/TravelForWorkYourVehicleView.scala.html
+++ b/app/views/journeys/expenses/travelAndAccommodation/TravelForWorkYourVehicleView.scala.html
@@ -54,7 +54,8 @@
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages(s"travelForWorkYourVehicle.formLabel.$userType")).asPageHeading(Medium)
+                label = LabelViewModel(messages(s"travelForWorkYourVehicle.formLabel.$userType"))
+                .withCssClass("govuk-heading-m")
             )
             .withWidth(Full)
         )

--- a/app/views/journeys/expenses/travelAndAccommodation/YourFlatRateForVehicleExpensesView.scala.html
+++ b/app/views/journeys/expenses/travelAndAccommodation/YourFlatRateForVehicleExpensesView.scala.html
@@ -54,7 +54,8 @@
             @govukRadios(
                 RadiosViewModel(
                     field  = form("value"),
-                    legend =  LegendViewModel(messages(s"yourFlatRateForVehicleExpenses.legend.$userType", totalFlatRateExpenses)).withCssClass("govuk-fieldset__legend--m"),
+                    legend =  LegendViewModel(messages(s"yourFlatRateForVehicleExpenses.legend.$userType", totalFlatRateExpenses))
+                    .withCssClass("govuk-fieldset__legend--m"),
                     items  = YourFlatRateForVehicleExpenses.options(totalFlatRateExpenses)
                 )
             )

--- a/app/views/journeys/expenses/workplaceRunningCosts/workingFromBusinessPremises/LiveAtBusinessPremisesView.scala.html
+++ b/app/views/journeys/expenses/workplaceRunningCosts/workingFromBusinessPremises/LiveAtBusinessPremisesView.scala.html
@@ -44,19 +44,9 @@
         @govukRadios(
             RadiosViewModel.yesNoVertical(
                 field = form("value"),
-                legend = LegendViewModel(HtmlContent(
-                    s"""
-                        <div>
-                            <label class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                                ${messages(s"liveAtBusinessPremises.title.$userType")}
-                            </label>
-                            <div class="govuk-hint">
-                                ${messages(s"liveAtBusinessPremises.hint.$userType")}
-                            </div>
-                        </div>
-                        """))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
-            )
+                legend = LegendViewModel(messages(s"liveAtBusinessPremises.title.$userType"))
+                .withCssClass("govuk-fieldset__legend--m")
+           ).withHint(HintViewModel(messages(s"liveAtBusinessPremises.hint.$userType")))
         )
 
         @submitButton()

--- a/app/views/journeys/expenses/workplaceRunningCosts/workingFromBusinessPremises/WfbpFlatRateOrActualCostsView.scala.html
+++ b/app/views/journeys/expenses/workplaceRunningCosts/workingFromBusinessPremises/WfbpFlatRateOrActualCostsView.scala.html
@@ -68,8 +68,7 @@
         @govukRadios(
             RadiosViewModel(
                 field = form("value"),
-                legend = LegendViewModel(messages(s"wfbpFlatRateOrActualCosts.subHeading.$userType", flatRateViewModel.flatRate))
-                            .asPageHeading(size = Medium),
+                legend = LegendViewModel(messages(s"wfbpFlatRateOrActualCosts.subHeading.$userType", flatRateViewModel.flatRate)),
                 items = WfbpFlatRateOrActualCosts.options(formatMoney(flatRateViewModel.flatRate))
             )
         )

--- a/app/views/journeys/expenses/workplaceRunningCosts/workingFromHome/WfhFlatRateOrActualCostsView.scala.html
+++ b/app/views/journeys/expenses/workplaceRunningCosts/workingFromHome/WfhFlatRateOrActualCostsView.scala.html
@@ -68,8 +68,7 @@
         @govukRadios(
             RadiosViewModel(
                 field = form("value"),
-                legend = LegendViewModel(messages(s"wfhFlatRateOrActualCosts.subHeading.$userType", flatRateViewModel.flatRate))
-                            .asPageHeading(size = Medium),
+                legend = LegendViewModel(messages(s"wfhFlatRateOrActualCosts.subHeading.$userType", flatRateViewModel.flatRate)),
                 items = WfhFlatRateOrActualCosts.options(formatMoney(flatRateViewModel.flatRate))
             )
         )

--- a/app/views/journeys/income/AnyOtherIncomeView.scala.html
+++ b/app/views/journeys/income/AnyOtherIncomeView.scala.html
@@ -17,14 +17,14 @@
 @import controllers.journeys.income.routes
 @import models.common.{BusinessId, TaxYear, UserType}
 @import views.html.components._
+@import viewmodels.LegendSize.Large
 
 @this(
         layout: templates.Layout,
         formHelper: FormWithCSRF,
         errorSummarySection: ErrorSummarySection,
         govukRadios: GovukRadios,
-        submitButton: SubmitButton,
-        heading: Heading
+        submitButton: SubmitButton
 )
 
 @(form: Form[_], mode: Mode, userType: UserType, taxYear: TaxYear, businessId: BusinessId)(implicit request: Request[_], messages: Messages)
@@ -33,14 +33,12 @@
 
     @errorSummarySection(form)
 
-    @heading(s"anyOtherIncome.title.$userType")
-
     @formHelper(action = routes.AnyOtherIncomeController.onSubmit(taxYear, businessId, mode), Symbol("autoComplete") -> "off") {
 
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel("")
+                legend = LegendViewModel(messages(s"anyOtherIncome.title.$userType")).asPageHeading(Large)
             )
         )
 

--- a/app/views/journeys/income/HowMuchTradingAllowanceView.scala.html
+++ b/app/views/journeys/income/HowMuchTradingAllowanceView.scala.html
@@ -51,7 +51,7 @@
             RadiosViewModel(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"howMuchTradingAllowance.subHeading.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m"),
+                .withCssClass("govuk-fieldset__legend--m"),
                 items = HowMuchTradingAllowance.options(tradingAllowance)
             )
         )

--- a/app/views/journeys/income/IncomeNotCountedAsTurnoverView.scala.html
+++ b/app/views/journeys/income/IncomeNotCountedAsTurnoverView.scala.html
@@ -50,7 +50,7 @@
             RadiosViewModel.yesNo(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"incomeNotCountedAsTurnover.subHeading.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                .withCssClass("govuk-fieldset__legend--m")
             )
         )
 

--- a/app/views/journeys/income/NotTaxableAmountView.scala.html
+++ b/app/views/journeys/income/NotTaxableAmountView.scala.html
@@ -49,6 +49,6 @@
             .withPrefix(PrefixOrSuffix(content = Text("£")))
         )
 
-        @submitButton(extraClasses = "govuk-!-margin-top-2")
+        @submitButton()
     }
 }

--- a/app/views/journeys/income/TradingAllowanceAmountView.scala.html
+++ b/app/views/journeys/income/TradingAllowanceAmountView.scala.html
@@ -49,6 +49,6 @@
             .withPrefix(PrefixOrSuffix(content = Text("£")))
         )
 
-        @submitButton(extraClasses = "govuk-!-margin-top-2")
+        @submitButton()
     }
 }

--- a/app/views/journeys/income/TradingAllowanceView.scala.html
+++ b/app/views/journeys/income/TradingAllowanceView.scala.html
@@ -73,7 +73,7 @@
             RadiosViewModel(
                 field  = form("value"),
                 legend = LegendViewModel(messages(s"tradingAllowance.subHeading.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m"),
+                .withCssClass("govuk-fieldset__legend--m"),
                 items = TradingAllowance.options
             )
         )

--- a/app/views/journeys/income/TurnoverIncomeAmountView.scala.html
+++ b/app/views/journeys/income/TurnoverIncomeAmountView.scala.html
@@ -55,7 +55,7 @@
             InputViewModel(
                 field = form("value"),
                 label = LabelViewModel(messages(s"turnoverIncomeAmount.subHeading.$userType"))
-                .asPageHeading(LabelSize.Medium)
+                .withCssClass("govuk-label--m")
             )
             .asNumeric()
             .withHint(HintViewModel(messages("site.hint.large.amount")))
@@ -63,6 +63,6 @@
             .withPrefix(PrefixOrSuffix(content = Text("£")))
         )
 
-        <div class="govuk-!-margin-top-7">@submitButton()</div>
+        @submitButton()
     }
 }

--- a/app/views/journeys/income/TurnoverNotTaxableView.scala.html
+++ b/app/views/journeys/income/TurnoverNotTaxableView.scala.html
@@ -52,7 +52,7 @@
             RadiosViewModel.yesNo(
                 field = form("value"),
                 legend = LegendViewModel(messages(s"income.turnoverExemptFromTax.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--m")
+                .withCssClass("govuk-fieldset__legend--m")
             )
         )
 

--- a/app/views/journeys/nics/Class4ExemptionReasonView.scala.html
+++ b/app/views/journeys/nics/Class4ExemptionReasonView.scala.html
@@ -17,6 +17,7 @@
 @import controllers.journeys.nics.routes
 @import models.common.{TaxYear, UserType}
 @import models.journeys.nics.ExemptionReason
+@import viewmodels.LegendSize.Large
 @import views.html.components._
 
 @this(
@@ -39,7 +40,7 @@
             RadiosViewModel(
                 field  = form("value"),
                 legend = LegendViewModel(messages(s"class4ExemptionReason.title.$userType"))
-                .withCssClass("govuk-fieldset__legend govuk-fieldset__legend--l"),
+                .asPageHeading(size = Large),
                 items  = ExemptionReason.options(userType)
             )
         )

--- a/app/views/journeys/nics/Class4NonDivingExemptYesNoView.scala.html
+++ b/app/views/journeys/nics/Class4NonDivingExemptYesNoView.scala.html
@@ -16,6 +16,7 @@
 
 @import controllers.journeys.nics.routes
 @import models.common.{TaxYear, UserType}
+@import viewmodels.LegendSize.Large
 @import views.html.components._
 
 @this(
@@ -23,24 +24,23 @@
         formHelper: FormWithCSRF,
         errorSummarySection: ErrorSummarySection,
         govukRadios: GovukRadios,
-        submitButton: SubmitButton,
-        heading: Heading
+        submitButton: SubmitButton
 )
 
 @(form: Form[_], taxYear: TaxYear, userType: UserType, mode: Mode, businessName: String)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, s"${messages(s"class4NonDivingExemptSingleBusiness.subHeading.$userType")} $businessName.")) {
 
-    @heading(s"${messages(s"class4NonDivingExemptSingleBusiness.subHeading.$userType")} $businessName.")
-
     @formHelper(action = routes.Class4NonDivingExemptSingleBusinessController.onSubmit(taxYear, mode), Symbol("autoComplete") -> "off") {
 
         @errorSummarySection(form)
 
+
         @govukRadios(
             RadiosViewModel.yesNoVertical(
-                field = form("value"),
-                legend = LegendViewModel(s"")
+                field  = form("value"),
+                legend = LegendViewModel(s"${messages(s"class4NonDivingExemptSingleBusiness.subHeading.$userType")} $businessName.")
+                .asPageHeading(size = Large)
             )
         )
 

--- a/app/views/journeys/prepop/AdjustmentsSummaryView.scala.html
+++ b/app/views/journeys/prepop/AdjustmentsSummaryView.scala.html
@@ -34,12 +34,12 @@
     @caption(taxYear)
     @heading("adjustments.businessAdjustments")
 
-    <p class="govuk-body">@messages("prepop.useReportingSoftware")</p>
+    <div class="govuk-form-group">
+        <p class="govuk-body">@messages("prepop.useReportingSoftware")</p>
 
-    @govukTable(adjustmentsTable)
-
-    <div class="govuk-!-margin-top-7">
-        @button(journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, AdjustmentsPrepop, NormalMode).url, "site.continue")
+        @govukTable(adjustmentsTable)
     </div>
+
+    @button(journeys.routes.SectionCompletedStateController.onPageLoad(taxYear, businessId, AdjustmentsPrepop, NormalMode).url, "site.continue")
 
 }


### PR DESCRIPTION
Fixes included in this PR:
- removing additional h1's from pages with more than 1 h1. Done by updating addition h1's to h2's (new component added for this) and removing the .isPageHeading setting from label and legends where appropriate
- adding in h1's with pages missing h1's. Done by correctly implementing .isPageHeading setting, thus not leaving label and legends empty
- correctly implementing hint text with components where needed. Thgis is because otherwise hint text isn't linked to inputs correctly
- removing excess classes, in most cases classes repeated in components
- removing details components from label and legends in components and implementing them inline with recommended accessibility guidelines
- lots of general code tidying up, removing and correcting bad practice